### PR TITLE
Fix memory leak in SQL instrumentation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ History
 0.4.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix memory leak in SQL instrumentation
 
 
 0.4.0 (2016-02-26)


### PR DESCRIPTION
The additional member variables _cursor and _connection were causing circular references, prventing cursor and connection from being garbage collected.  Switched to use __wrapped__ property already available from the base class wrapt.ObjectProxy.