### PR TITLE
Quote/unquote values of TEXT_MAP carrier when passing via HTTP headers

### DIFF
--- a/opentracing_instrumentation/http_client.py
+++ b/opentracing_instrumentation/http_client.py
@@ -20,6 +20,7 @@
 
 from __future__ import absolute_import
 import re
+import urllib
 import opentracing
 from opentracing import Format
 from opentracing.ext import tags
@@ -61,7 +62,7 @@ def before_http_request(request, current_span_extractor):
         opentracing.tracer.inject(span=span, format=Format.TEXT_MAP,
                                   carrier=carrier)
         for key, value in carrier.iteritems():
-            request.add_header(key, value)
+            request.add_header(key, urllib.quote(value))
     except opentracing.UnsupportedFormatException:
         pass
 

--- a/opentracing_instrumentation/http_server.py
+++ b/opentracing_instrumentation/http_server.py
@@ -21,7 +21,7 @@
 from __future__ import absolute_import
 
 import logging
-
+import urllib
 import opentracing
 from opentracing import Format
 from opentracing.ext import tags
@@ -45,9 +45,12 @@ def before_request(request, tracer=None):
 
     operation = request.operation
     try:
+        carrier = {}
+        for key, value in request.headers.iteritems():
+            carrier[key] = urllib.unquote(value)
         span = tracer.join(operation_name=operation,
                            format=Format.TEXT_MAP,
-                           carrier=request.headers)
+                           carrier=carrier)
     except Exception as e:
         logging.exception('join failed: %s' % e)
         span = None

--- a/tests/opentracing_instrumentation/test_middleware.py
+++ b/tests/opentracing_instrumentation/test_middleware.py
@@ -69,7 +69,7 @@ def test_middleware(with_peer_tags):
         assert span == span2
         join_trace.assert_called_with(operation_name='my-test',
                                       format=Format.TEXT_MAP,
-                                      carrier=request.headers)
+                                      carrier={})
         span.set_tag.assert_any_call('http.url', request.full_url)
         if with_peer_tags:
             span.set_tag.assert_any_call(tags.PEER_HOST_IPV4, 'localhost')


### PR DESCRIPTION
Unit tests in this repo can be improved significantly by using a real tracer implementation, such as https://github.com/opentracing/basictracer-python