### PR TITLE
Change request context from span to a wrapper object

### DIFF
--- a/opentracing_instrumentation/__init__.py
+++ b/opentracing_instrumentation/__init__.py
@@ -19,5 +19,6 @@
 # THE SOFTWARE.
 from __future__ import absolute_import
 from .request_context import get_current_span  # noqa
-from .request_context import RequestContextManager  # noqa
+from .request_context import span_in_context  # noqa
+from .request_context import span_in_stack_context  # noqa
 from .local_span import traced_function  # noqa

--- a/opentracing_instrumentation/request_context.py
+++ b/opentracing_instrumentation/request_context.py
@@ -23,90 +23,56 @@ import threading
 import tornado.stack_context
 
 
+class RequestContext(object):
+    """
+    RequestContext represents the context of a request being executed.
+
+    Useful when a service needs to make downstream calls to other services
+    and requires access to some aspects of the original request, such as
+    tracing information.
+
+    It is designed to hold a reference to the current OpenTracing Span,
+    but the class can be extended to store more information.
+    """
+
+    __slots__ = ('span', )
+
+    def __init__(self, span):
+        self.span = span
+
+
 class RequestContextManager(object):
-    """A context manager that saves tracing span in per-thread state globally.
+    """A context manager that saves RequestContext in thread-local state.
 
     Intended for use with ThreadSafeStackContext (a thread-safe
     replacement for Tornado's StackContext) or as context manager
     in a WSGI middleware.
-
-    ## Usage with ThreadSafeStackContext
-
-    Suppose you have a method `handle_request(request)` in the http server.
-    Instead of calling it directly, use a wrapper:
-
-    .. code-block:: python
-
-        from opentracing_instrumentation import request_context
-
-        @tornado.gen.coroutine
-        def handle_request_wrapper(request, actual_handler, *args, **kwargs)
-
-            request_wrapper = TornadoRequestWrapper(request=request)
-            span = http_server.before_request(request=request_wrapper)
-
-            mgr = lambda: RequestContextManager(span)
-            with request_context.ThreadSafeStackContext(mgr):
-                return actual_handler(*args, **kwargs)
-
-    ## Usage with WSGI middleware:
-
-    .. code-block:: python
-
-        def create_wsgi_tracing_middleware(other_wsgi):
-
-            def wsgi_tracing_middleware(environ, start_response):
-                request = WSGIRequestWrapper.from_wsgi_environ(environ)
-                span = before_request(request=request, tracer=tracer)
-
-                # Wrapper around the real start_response object to log
-                # additional information to opentracing Span
-                def start_response_wrapper(status, response_headers,
-                                           exc_info=None):
-                    if exc_info is not None:
-                        span.log(event='exception', payload=exc_info)
-                    span.finish()
-
-                    return start_response(status, response_headers)
-
-                with RequestContextManager(span=span):
-                    return other_wsgi(environ, start_response_wrapper)
-
-            return wsgi_tracing_middleware
-
     """
 
     _state = threading.local()
-    _state.span = None
+    _state.context = None
 
     @classmethod
-    def current_span(cls):
-        """Get the current tracing span.
+    def current_context(cls):
+        """Get the current request context.
 
-        :rtype: opentracing.Span
-        :returns: The current tracing span, or None if no span was started.
+        :rtype: opentracing_instrumentation.RequestContext
+        :returns: The current request context, or None.
         """
+        return getattr(cls._state, 'context', None)
 
-        return getattr(cls._state, 'span', None)
-
-    def __init__(self, span):
-        self._span = span
+    def __init__(self, context):
+        self._context = context
 
     def __enter__(self):
-        self._prev_span = self.__class__.current_span()
-        self.__class__._state.span = self._span
+        self._prev_context = self.__class__.current_context()
+        self.__class__._state.context = self._context
+        return self._context
 
     def __exit__(self, *_):
-        self.__class__._state.span = self._prev_span
-        self._prev_span = None
+        self.__class__._state.context = self._prev_context
+        self._prev_context = None
         return False
-
-
-def get_current_span():
-    """
-    :return: Current span associated with the current stack context, or None.
-    """
-    return RequestContextManager.current_span()
 
 
 class ThreadSafeStackContext(tornado.stack_context.StackContext):
@@ -149,7 +115,7 @@ class ThreadSafeStackContext(tornado.stack_context.StackContext):
         context.__exit__(type, value, traceback)
     ```
 
-    Unexpected semantics:
+    Unexpected semantics of Tornado's default StackContext implementation:
 
     - There exist a race on `self.contexts`, where thread A enters a
       context, thread B enters a context, and thread A exits its context.
@@ -182,3 +148,87 @@ class ThreadSafeStackContext(tornado.stack_context.StackContext):
         if hasattr(self, 'contexts'):
             # only patch if context exists
             self.contexts = LocalContexts()
+
+
+def get_current_span():
+    """
+    Access current request context and extract current Span from it.
+    :return:
+        Return current span associated with the current request context.
+        If no request context is present in thread local, or the context
+        has no span, return None.
+    """
+    context = RequestContextManager.current_context()
+    return context.span if context else None
+
+
+def span_in_context(span):
+    """
+    Create a context manager that stores the given span in the thread-local
+    request context. This function should only be used in single-threaded
+    applications like Flask / uWSGI.
+
+    ## Usage example in WSGI middleware:
+
+    .. code-block:: python
+
+        def create_wsgi_tracing_middleware(other_wsgi):
+
+            def wsgi_tracing_middleware(environ, start_response):
+                request = WSGIRequestWrapper.from_wsgi_environ(environ)
+                span = before_request(request=request, tracer=tracer)
+
+                # Wrapper around the real start_response object to log
+                # additional information to opentracing Span
+                def start_response_wrapper(status, response_headers,
+                                           exc_info=None):
+                    if exc_info is not None:
+                        span.log(event='exception', payload=exc_info)
+                    span.finish()
+
+                    return start_response(status, response_headers)
+
+                with request_context.span_in_context(span):
+                    return other_wsgi(environ, start_response_wrapper)
+
+            return wsgi_tracing_middleware
+
+    :param span: OpenTracing Span
+    :return:
+        Return context manager that wraps the request context.
+    """
+    context = RequestContext(span)
+    return RequestContextManager(context)
+
+
+def span_in_stack_context(span):
+    """
+    Create Tornado's StackContext that stores the given span in the
+    thread-local request context. This function is intended for use
+    in Tornado applications based on IOLoop, although will work fine
+    in single-threaded apps like Flask, albeit with more overhead.
+
+    ## Usage example in Tornado application
+
+    Suppose you have a method `handle_request(request)` in the http server.
+    Instead of calling it directly, use a wrapper:
+
+    .. code-block:: python
+
+        from opentracing_instrumentation import request_context
+
+        @tornado.gen.coroutine
+        def handle_request_wrapper(request, actual_handler, *args, **kwargs)
+
+            request_wrapper = TornadoRequestWrapper(request=request)
+            span = http_server.before_request(request=request_wrapper)
+
+            with request_context.span_in_stack_context(span):
+                return actual_handler(*args, **kwargs)
+
+    :param span:
+    :return:
+        Return StackContext that wraps the request context.
+    """
+    context = RequestContext(span)
+    return ThreadSafeStackContext(lambda: RequestContextManager(context))

--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,8 @@ setup(
             'pytest>=2.7',
             'pytest-cov',
             'pytest-mock',
+            'pytest-tornado',
+            'basictracer==1.0rc1',
             'Sphinx',
             'sphinx_rtd_theme',
         ]

--- a/tests/opentracing_instrumentation/test_local_span.py
+++ b/tests/opentracing_instrumentation/test_local_span.py
@@ -23,8 +23,7 @@ import opentracing
 from opentracing_instrumentation.local_span import func_span
 from opentracing_instrumentation.client_hooks._dbapi2 import db_span, _COMMIT
 from opentracing_instrumentation.client_hooks._singleton import singleton
-from opentracing_instrumentation import RequestContextManager
-from opentracing import Tracer
+from opentracing_instrumentation import span_in_context
 
 
 def test_func_span_without_parent():
@@ -37,7 +36,7 @@ def test_func_span_without_parent():
 def test_func_span():
     tracer = opentracing.tracer
     span = tracer.start_span(operation_name='parent')
-    with RequestContextManager(span=span):
+    with span_in_context(span=span):
         with func_span('test') as child_span:
             assert span is child_span
         with func_span('test', tags={'x': 'y'}) as child_span:
@@ -52,7 +51,7 @@ def test_db_span_without_parent():
 def test_db_span():
     tracer = opentracing.tracer
     span = tracer.start_span(operation_name='parent')
-    with RequestContextManager(span=span):
+    with span_in_context(span=span):
         with db_span(_COMMIT, 'MySQLdb') as child_span:
             assert span is child_span
         with db_span('select * from X', 'MySQLdb') as child_span:

--- a/tests/opentracing_instrumentation/test_sync_client_hooks.py
+++ b/tests/opentracing_instrumentation/test_sync_client_hooks.py
@@ -28,7 +28,7 @@ from tornado.httputil import HTTPHeaders
 import opentracing
 from opentracing_instrumentation.client_hooks import urllib2 as urllib2_hooks
 from opentracing_instrumentation.config import CONFIG
-from opentracing_instrumentation.request_context import RequestContextManager
+from opentracing_instrumentation.request_context import span_in_context
 
 
 @contextlib.contextmanager
@@ -109,7 +109,7 @@ def _do_test(scheme='http', root_span=True):
             with mock.patch.object(opentracing.tracer,
                                    'start_span',
                                    return_value=span) as start_child:
-                with RequestContextManager(current_span):
+                with span_in_context(span=current_span):
                     resp = urllib2.urlopen(request)
                     start_child.assert_called_once_with(
                         operation_name='GET:antiquing',

--- a/tests/opentracing_instrumentation/test_tornado_http.py
+++ b/tests/opentracing_instrumentation/test_tornado_http.py
@@ -1,0 +1,86 @@
+
+import pytest
+import threading
+import tornado.gen
+import tornado.web
+import tornado.httpserver
+import tornado.netutil
+import tornado.httpclient
+from mock import patch
+from opentracing_instrumentation import span_in_stack_context
+from opentracing_instrumentation.client_hooks.tornado_http \
+    import install_patches, reset_patchers
+from basictracer import BasicTracer, SpanRecorder
+import opentracing
+from opentracing import Format
+
+
+class Handler(tornado.web.RequestHandler):
+
+    def get(self):
+        span = opentracing.tracer.join(
+            'server', Format.TEXT_MAP, self.request.headers)
+        self.write('{:x}'.format(span.context.trace_id))
+        self.set_status(200)
+
+
+@pytest.fixture
+def app():
+    return tornado.web.Application([
+        (r"/", Handler)
+    ])
+
+
+@pytest.yield_fixture
+def tornado_http_patch():
+    install_patches.__original_func()
+    try:
+        yield None
+    finally:
+        reset_patchers()
+
+
+@pytest.fixture
+def span_recorder():
+    class InMemoryRecorder(SpanRecorder):
+        def __init__(self):
+            self.spans = []
+            self.mux = threading.Lock()
+
+        def record_span(self, span):
+            with self.mux:
+                self.spans.append(span)
+
+        def get_spans(self):
+            with self.mux:
+                return self.spans[:]
+
+    return InMemoryRecorder()
+
+
+@pytest.fixture
+def tracer(span_recorder):
+    return BasicTracer(recorder=span_recorder)
+
+
+@pytest.mark.gen_test(run_sync=False)
+def test_http_fetch(base_url, http_client, tornado_http_patch, tracer):
+
+    @tornado.gen.coroutine
+    def make_downstream_call():
+        resp = yield http_client.fetch(base_url)
+        raise tornado.gen.Return(resp)
+
+    with patch('opentracing.tracer', tracer):
+        assert opentracing.tracer == tracer  # sanity check that patch worked
+
+        span = tracer.start_span('test')
+        trace_id = '{:x}'.format(span.context.trace_id)
+
+        with span_in_stack_context(span):
+            response = make_downstream_call()
+        response = yield response  # cannot yield when in StackContext context
+
+        span.finish()
+    assert response.code == 200
+    assert response.body == trace_id

--- a/tests/opentracing_instrumentation/test_traced_function_decorator.py
+++ b/tests/opentracing_instrumentation/test_traced_function_decorator.py
@@ -27,7 +27,7 @@ import tornado.concurrent
 from tornado import gen
 from tornado.testing import AsyncTestCase, gen_test
 from opentracing_instrumentation import traced_function
-from opentracing_instrumentation import RequestContextManager
+from opentracing_instrumentation import span_in_stack_context
 
 patch_object = mock.patch.object
 
@@ -205,6 +205,5 @@ def run_coroutine_with_span(span, coro, *args, **kwargs):
     :param args: Positional args to func, if any.
     :param kwargs: Keyword args to func, if any.
     """
-    mgr = lambda: RequestContextManager(span)
-    with tornado.stack_context.StackContext(mgr):
+    with span_in_stack_context(span=span):
         return coro(*args, **kwargs)


### PR DESCRIPTION
In order to substitute TChannel's native trace reporting, we want to override its tracing hook, as well as its  RequestContextProvider. That requires the request context from this module to be extensible. Currently it only stores the Span, so this change introduces a `RequestContext` class that wraps the span and can be further extended.