### PR TITLE
Support backwards compatible usage of RequestContextManager with span argument

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ History
 1.1.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Support backwards compatible usage of RequestContextManager with span argument
 
 
 1.1.0 (2016-06-09)

--- a/opentracing_instrumentation/request_context.py
+++ b/opentracing_instrumentation/request_context.py
@@ -20,6 +20,8 @@
 
 from __future__ import absolute_import
 import threading
+
+import opentracing
 import tornado.stack_context
 
 
@@ -61,8 +63,15 @@ class RequestContextManager(object):
         """
         return getattr(cls._state, 'context', None)
 
-    def __init__(self, context):
-        self._context = context
+    def __init__(self, context=None, span=None):
+        # normally we want the context parameter, but for backwards
+        # compatibility we make it optional and allow span as well
+        if span:
+            self._context = RequestContext(span=span)
+        elif isinstance(context, opentracing.Span):
+            self._context = RequestContext(span=context)
+        else:
+            self._context = context
 
     def __enter__(self):
         self._prev_context = self.__class__.current_context()

--- a/tests/opentracing_instrumentation/test_tornado_request_context.py
+++ b/tests/opentracing_instrumentation/test_tornado_request_context.py
@@ -20,6 +20,7 @@
 
 from __future__ import absolute_import
 
+import opentracing
 import tornado.stack_context
 from tornado import gen
 from tornado.testing import AsyncTestCase, gen_test
@@ -59,6 +60,15 @@ class TornadoTraceContextTest(AsyncTestCase):
         ctx = RequestContextManager(context=RequestContext(span='x'))
         assert ctx._context.span == 'x'
         assert RequestContextManager.current_context() is None
+
+    def test_backwards_compatible(self):
+        span = opentracing.Span(tracer=None)
+        mgr = RequestContextManager(span)  # span as positional arg
+        assert mgr._context.span == span
+        mgr = RequestContextManager(context=span)  # span context arg
+        assert mgr._context.span == span
+        mgr = RequestContextManager(span=span)  # span as span arg
+        assert mgr._context.span == span
 
 
 def run_coroutine_with_span(span, coro, *args, **kwargs):


### PR DESCRIPTION
Our 1.x clients were using `RequestContextManager(span)` API, which got broken in `opentracing_instrumentation>=1.1`. This change restores the prior syntax as an alternative way.