### PR TITLE
fix an error where redis.key would be used across redis command invocations

### DIFF
--- a/opentracing_instrumentation/client_hooks/strict_redis.py
+++ b/opentracing_instrumentation/client_hooks/strict_redis.py
@@ -99,6 +99,7 @@ def install_patches():
         # for certain commands we'll add extra attributes such as the redis key
         for tag_key, tag_val in getattr(self, '_extra_tags', []):
             span.set_tag(tag_key, tag_val)
+        self._extra_tags = []
 
         with span:
             return ORIG_METHODS['execute_command'](self, cmd, *args, **kwargs)


### PR DESCRIPTION
This fixes a bug where the `redis.key` attribute would be used across redis command invocations. A test is also added.

I switched all of the tests away from mock objects, since the mock objects made my test harder to write. I'm just using monkeypatch, which I think is cleaner.