### PR TITLE
string_escape keys

### DIFF
--- a/opentracing_instrumentation/client_hooks/strict_redis.py
+++ b/opentracing_instrumentation/client_hooks/strict_redis.py
@@ -98,6 +98,8 @@ def install_patches():
 
         # for certain commands we'll add extra attributes such as the redis key
         for tag_key, tag_val in getattr(self, '_extra_tags', []):
+            if isinstance(tag_val, basestring):
+                tag_val = tag_val.encode('string_escape')
             span.set_tag(tag_key, tag_val)
         self._extra_tags = []
 

--- a/tests/opentracing_instrumentation/test_redis.py
+++ b/tests/opentracing_instrumentation/test_redis.py
@@ -88,7 +88,7 @@ def spans(monkeypatch):
 
 
 def check_span(span, key):
-    assert span.tags['redis.key'] == key
+    assert span.tags['redis.key'] == key.encode('string_escape')
     assert span.tags[tags.SPAN_KIND] == tags.SPAN_KIND_RPC_CLIENT
     assert span.tags[tags.PEER_SERVICE] == 'redis'
 


### PR DESCRIPTION
This makes sure keys are valid string data, since they can contain binary data.