### PR TITLE
fix monkeypatched argument names in redis hooks

### DIFF
--- a/opentracing_instrumentation/client_hooks/strict_redis.py
+++ b/opentracing_instrumentation/client_hooks/strict_redis.py
@@ -68,22 +68,22 @@ def install_patches():
     for name in METHOD_NAMES:
         ORIG_METHODS[name] = getattr(redis.StrictRedis, name)
 
-    def get(self, name):
+    def get(self, name, **kwargs):
         self._extra_tags = [('redis.key', name)]
-        return ORIG_METHODS['get'](self, name)
+        return ORIG_METHODS['get'](self, name, **kwargs)
 
-    def set(self, name, value):
+    def set(self, name, value, **kwargs):
         self._extra_tags = [('redis.key', name)]
-        return ORIG_METHODS['set'](self, name, value)
+        return ORIG_METHODS['set'](self, name, value, **kwargs)
 
-    def setex(self, name, time, value):
+    def setex(self, name, time, value, **kwargs):
         self._extra_tags = [('redis.key', name),
                             ('redis.ttl', time)]
-        return ORIG_METHODS['setex'](self, name, time, value)
+        return ORIG_METHODS['setex'](self, name, time, value, **kwargs)
 
-    def setnx(self, name, value):
+    def setnx(self, name, value, **kwargs):
         self._extra_tags = [('redis.key', name)]
-        return ORIG_METHODS['setnx'](self, name, value)
+        return ORIG_METHODS['setnx'](self, name, value, **kwargs)
 
     def execute_command(self, cmd, *args, **kwargs):
         operation_name = 'redis:%s' % (cmd,)

--- a/opentracing_instrumentation/client_hooks/strict_redis.py
+++ b/opentracing_instrumentation/client_hooks/strict_redis.py
@@ -68,22 +68,22 @@ def install_patches():
     for name in METHOD_NAMES:
         ORIG_METHODS[name] = getattr(redis.StrictRedis, name)
 
-    def get(self, key):
-        self._extra_tags = [('redis.key', key)]
-        return ORIG_METHODS['get'](self, key)
+    def get(self, name):
+        self._extra_tags = [('redis.key', name)]
+        return ORIG_METHODS['get'](self, name)
 
-    def set(self, key, val):
-        self._extra_tags = [('redis.key', key)]
-        return ORIG_METHODS['set'](self, key, val)
+    def set(self, name, value):
+        self._extra_tags = [('redis.key', name)]
+        return ORIG_METHODS['set'](self, name, value)
 
-    def setex(self, key, ttl, val):
-        self._extra_tags = [('redis.key', key),
-                            ('redis.ttl', ttl)]
-        return ORIG_METHODS['setex'](self, key, ttl, val)
+    def setex(self, name, time, value):
+        self._extra_tags = [('redis.key', name),
+                            ('redis.ttl', time)]
+        return ORIG_METHODS['setex'](self, name, time, value)
 
-    def setnx(self, key, val):
-        self._extra_tags = [('redis.key', key)]
-        return ORIG_METHODS['setnx'](self, key, val)
+    def setnx(self, name, value):
+        self._extra_tags = [('redis.key', name)]
+        return ORIG_METHODS['setnx'](self, name, value)
 
     def execute_command(self, cmd, *args, **kwargs):
         operation_name = 'redis:%s' % (cmd,)


### PR DESCRIPTION
This fixes an issue where callers using kwargs would get errors, because
the parameter names used in the monkeypatched functions were different.
This also fixes the ordering of args for setex (curiously it uses a
different ordering than the redis wire protocol).