### PR TITLE
Remove url encoding when using HTTP_HEADERS format

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,10 +3,10 @@
 History
 -------
 
-2.0.4 (unreleased)
+2.1.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Remove url encoding/decoding when using HTTP_HEADERS codecs
 
 
 2.0.3 (2016-08-11)

--- a/opentracing_instrumentation/http_client.py
+++ b/opentracing_instrumentation/http_client.py
@@ -20,7 +20,6 @@
 
 from __future__ import absolute_import
 import re
-import urllib
 import opentracing
 from opentracing import Format
 from opentracing.ext import tags
@@ -64,7 +63,7 @@ def before_http_request(request, current_span_extractor):
                                   format=Format.HTTP_HEADERS,
                                   carrier=carrier)
         for key, value in carrier.iteritems():
-            request.add_header(key, urllib.quote(value))
+            request.add_header(key, value)
     except opentracing.UnsupportedFormatException:
         pass
 

--- a/opentracing_instrumentation/http_server.py
+++ b/opentracing_instrumentation/http_server.py
@@ -66,7 +66,7 @@ def before_request(request, tracer=None):
     try:
         carrier = {}
         for key, value in request.headers.iteritems():
-            carrier[key] = urllib.unquote(value)
+            carrier[key] = value
         parent_ctx = tracer.extract(
             format=Format.HTTP_HEADERS, carrier=carrier
         )
@@ -194,8 +194,6 @@ class WSGIRequestWrapper(AbstractRequestWrapper):
 
         :return: Reconstructed URL from WSGI environment.
         """
-        from urllib import quote
-
         environ = self.wsgi_environ
         url = environ['wsgi.url_scheme'] + '://'
 
@@ -211,8 +209,8 @@ class WSGIRequestWrapper(AbstractRequestWrapper):
                 if environ['SERVER_PORT'] != '80':
                     url += ':' + environ['SERVER_PORT']
 
-        url += quote(environ.get('SCRIPT_NAME', ''))
-        url += quote(environ.get('PATH_INFO', ''))
+        url += urllib.quote(environ.get('SCRIPT_NAME', ''))
+        url += urllib.quote(environ.get('PATH_INFO', ''))
         if environ.get('QUERY_STRING'):
             url += '?' + environ['QUERY_STRING']
         return url

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='opentracing_instrumentation',
-    version='2.0.4.dev0',
+    version='2.1.0.dev0',
     author='Yuri Shkuro',
     author_email='ys@uber.com',
     description='Tracing Instrumentation using OpenTracing API (http://opentracing.io)',


### PR DESCRIPTION
Per https://github.com/opentracing/opentracing.github.io/issues/113, it's the responsibility of the tracer to perform URL encoding.