### PR TITLE
Upgrade to opentracing 1.2 with KV logging

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,10 +3,10 @@
 History
 -------
 
-2.1.1 (unreleased)
+2.2.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Upgrade to opentracing 1.2 with KV logging
 
 
 2.1.0 (2016-09-08)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='opentracing_instrumentation',
-    version='2.1.1.dev0',
+    version='2.2.0.dev0',
     author='Yuri Shkuro',
     author_email='ys@uber.com',
     description='Tracing Instrumentation using OpenTracing API (http://opentracing.io)',
@@ -27,7 +27,7 @@ setup(
         'wrapt',
         'tornado>=4.1',
         'contextlib2',
-        'opentracing>=1.1,<1.2',
+        'opentracing>=1.1,<1.3',
     ],
     extras_require={
         'tests': [


### PR DESCRIPTION
The code is not actually using any of the new KV logging features,
therefore only the upper bound on opentracing is raised.