### PR TITLE
Add environment marker for dependency: 'futures'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,7 @@ check-virtualenv:
 bootstrap: check-virtualenv install-deps
 
 install-deps:
+	pip install 'setuptools>=20.8.1'
 	pip install -r requirements.txt
 	pip install -r requirements-test.txt
 	python setup.py develop

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     platforms='any',
     install_requires=[
         'future',
-        'futures',
+        'futures;python_version<"3"',
         'wrapt',
         'tornado>=4.1',
         'contextlib2',


### PR DESCRIPTION
'futures' is a Python 2 package only.

Fixes #32