### PR TITLE
Remove concurrent.futures dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,10 +11,14 @@ setup(
     url='https://github.com/uber-common/opentracing-python-instrumentation',
     keywords=['opentracing'],
     classifiers=[
-        'Development Status :: 3 - Alpha',
+        'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
@@ -24,11 +28,10 @@ setup(
     platforms='any',
     install_requires=[
         'future',
-        'futures;python_version<"3"',
         'wrapt',
         'tornado>=4.1',
         'contextlib2',
-        'opentracing>=1.1,<1.3',
+        'opentracing>=1.1,<2',
         'six',
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
     install_requires=[
         'future',
         'wrapt',
-        'tornado>=4.1',
+        'tornado>=4.1,<5',
         'contextlib2',
         'opentracing>=1.1,<2',
         'six',


### PR DESCRIPTION
I don't even know why we had it, since no code in this lib actually depends on `concurrent.futures`.