### PR TITLE
Fix gettattr for ContextManagerConnectionWrapper

### DIFF
--- a/opentracing_instrumentation/client_hooks/_dbapi2.py
+++ b/opentracing_instrumentation/client_hooks/_dbapi2.py
@@ -166,6 +166,7 @@ class ContextManagerConnectionWrapper(ConnectionWrapper):
         # https://gist.github.com/mjallday/3d4c92e7e6805af1e024.
         if name == '_sqla_unwrap':
             return self.__wrapped__
+        return super(ContextManagerConnectionWrapper, self).__getattr__(name)
 
     def __enter__(self):
         with func_span('%s:begin_transaction' % self._module_name):

--- a/tests/opentracing_instrumentation/test_postgres.py
+++ b/tests/opentracing_instrumentation/test_postgres.py
@@ -121,6 +121,6 @@ def test_db(tracer, engine, session):
     # If the test does not raised an error, it is passing
 
 @pytest.mark.skipif(not is_postgres_running(), reason='Postgres is not running or cannot connect')
-def test_connection_proxy(tracer, engine, session):
+def test_connection_proxy(tracer, engine):
     # Test that connection properties are proxied by ContextManagerConnectionWrapper
     assert engine.raw_connection().connection.closed == 0

--- a/tests/opentracing_instrumentation/test_postgres.py
+++ b/tests/opentracing_instrumentation/test_postgres.py
@@ -119,3 +119,8 @@ def test_db(tracer, engine, session):
     session.add(user1)
     session.add(user2)
     # If the test does not raised an error, it is passing
+
+@pytest.mark.skipif(not is_postgres_running(), reason='Postgres is not running or cannot connect')
+def test_connection_proxy(tracer, engine, session):
+    # Test that connection properties are proxied by ContextManagerConnectionWrapper
+    assert engine.raw_connection().connection.closed == 0


### PR DESCRIPTION
`ContextManagerConnectionWrapper` breaks __getattr__ of parent proxy class, which results in inaccessible properties for wrapped connection object.