### PR TITLE
WIP: Test, ignore

### DIFF
--- a/tests/opentracing_instrumentation/test_postgres.py
+++ b/tests/opentracing_instrumentation/test_postgres.py
@@ -119,3 +119,8 @@ def test_db(tracer, engine, session):
     session.add(user1)
     session.add(user2)
     # If the test does not raised an error, it is passing
+
+@pytest.mark.skipif(not is_postgres_running(), reason='Postgres is not running or cannot connect')
+def test_connection_proxy(tracer, engine):
+    # Test that connection properties are proxied by ContextManagerConnectionWrapper
+    assert engine.raw_connection().connection.closed == 0


### PR DESCRIPTION
a quick test to confirm the bug. The [build][1] failed with this error

```
=================================== FAILURES ===================================
____________________________ test_connection_proxy _____________________________
tests/opentracing_instrumentation/test_postgres.py:126: in test_connection_proxy
    assert engine.raw_connection().connection.closed == 0
E   assert None == 0
E    +  where None = <ContextManagerConnectionWrapper at 0x2b33b70c0f18 for psycopg2.extensions.connection at 0x2b33b6d8eb48>.closed
E    +    where <ContextManagerConnectionWrapper at 0x2b33b70c0f18 for psycopg2.extensions.connection at 0x2b33b6d8eb48> = <sqlalchemy.pool._ConnectionFairy object at 0x2b33b708b610>.connection
E    +      where <sqlalchemy.pool._ConnectionFairy object at 0x2b33b708b610> = <bound method Engine.raw_connection of Engine(postgresql://localhost/travis_ci_test)>()
E    +        where <bound method Engine.raw_connection of Engine(postgresql://localhost/travis_ci_test)> = Engine(postgresql://localhost/travis_ci_test).raw_connection
--------------------------- Captured stdout teardown ---------------------------
F
===================== 1 failed, 41 passed in 1.05 seconds ======================
make: *** [test] Error 1
```

[1]: https://travis-ci.org/uber-common/opentracing-python-instrumentation/jobs/416134335