### PR TITLE
Update supported Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
-sudo: required
+dist: xenial
+sudo: true
 
 language: python
 
@@ -6,10 +7,11 @@ matrix:
   include:
   - python: '2.7'
     env: COVER=1
-  - python: '3.3'
   - python: '3.4'
+    dist: trusty
   - python: '3.5'
   - python: '3.6'
+  - python: '3.7'
 
 install:
   - make install-ci
@@ -26,4 +28,3 @@ script:
 
 after_success:
   if [ "$COVER" = "1" ]; then coveralls -v ; fi
-

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,10 +3,13 @@
 History
 -------
 
-2.4.4 (unreleased)
+2.5.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add support for Python 3.7
+- Drop support of Python 3.3
+- Update the requirements
+- Fix flake8 warnings
 
 
 2.4.3 (2018-08-24)

--- a/Makefile
+++ b/Makefile
@@ -30,15 +30,8 @@ check-virtualenv:
 bootstrap: check-virtualenv install-deps
 
 install-deps:
-	# We need to limit to <40.0.0 as long as we support Python 3.3.
-	# See https://github.com/pypa/setuptools/commit/7392f01ffced3acfdef25b0b2d55cefdc6ee468a.
-	if [ "$$(python --version 2>&1 | sed 's/\.[0-9][0-9]*$$//g')" = "Python 3.3" ]; then \
-		pip install 'setuptools>=20.8.1,<40.0.0'; \
-	else \
-		pip install 'setuptools>=20.8.1'; \
-	fi
-	pip install -r requirements.txt
-	pip install -r requirements-test.txt
+	pip install -U pip setuptools wheel
+	pip install -U --upgrade-strategy eager -r requirements-test.txt
 	python setup.py develop
 
 install-ci: install-deps

--- a/setup.py
+++ b/setup.py
@@ -1,16 +1,17 @@
 from setuptools import setup, find_packages
 
-with open("README.md", "r") as fh:
+with open('README.md', 'r') as fh:
     long_description = fh.read()
 
 setup(
     name='opentracing_instrumentation',
-    version='2.4.4.dev0',
+    version='2.5.0.dev0',
     author='Yuri Shkuro',
     author_email='ys@uber.com',
-    description='Tracing Instrumentation using OpenTracing API (http://opentracing.io)',
+    description='Tracing Instrumentation using OpenTracing API '
+                '(http://opentracing.io)',
     long_description=long_description,
-    long_description_content_type="text/markdown",
+    long_description_content_type='text/markdown',
     license='MIT',
     url='https://github.com/uber-common/opentracing-python-instrumentation',
     keywords=['opentracing'],
@@ -19,10 +20,10 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
@@ -42,17 +43,21 @@ setup(
         'tests': [
             'coveralls',
             'doubles',
-            'flake8<3',  # see https://github.com/zheller/flake8-quotes/issues/29
+            'flake8',
             'flake8-quotes',
-            'mock<1.1.0',
-            'psycopg2>=2.4.0',
+            'mock',
+            'psycopg2-binary',
             'sqlalchemy>=1.2.0',
-            'pytest>=3.0.0',
+
+            # pytest-tornado isn't compatible with pytest>=4.0.0,
+            # see https://github.com/eugeniy/pytest-tornado/pull/38
+            'pytest>=3.0.0,<4.0.0',
+
             'pytest-cov',
             'pytest-localserver',
             'pytest-mock',
             'pytest-tornado',
-            'basictracer>=2.1,<2.2',
+            'basictracer>=2.1,<3',
             'redis',
             'Sphinx',
             'sphinx_rtd_theme',

--- a/tests/opentracing_instrumentation/test_sync_client_hooks.py
+++ b/tests/opentracing_instrumentation/test_sync_client_hooks.py
@@ -118,7 +118,7 @@ def test_urllib2(urllibver, scheme, root_span, install_hooks, tracer):
         )
     else:
         cls = module.AbstractHTTPHandler
-        p_do_open = mock._patch_object(
+        p_do_open = mock.patch.object(
             cls, 'do_open', return_value=Response()
         )
 


### PR DESCRIPTION
My intention here is to provide support for most recent Python version and on the other hand simplify maintenance by dropping stale version.

Status of Python branches:
https://devguide.python.org/#branchstatus

These changes:
 - Add support for Python 3.7
 - Drop support for Python 3.3
 - Update the requirements
 - Fix flake8 warnings