### PR TITLE
Add unit test for ThreadSafeStackContext

### DIFF
--- a/opentracing_instrumentation/request_context.py
+++ b/opentracing_instrumentation/request_context.py
@@ -89,7 +89,7 @@ class ThreadSafeStackContext(tornado.stack_context.StackContext):
     """
     Thread safe version of Tornado's StackContext (up to 4.3)
 
-    Copy of implementation by caspersj@, until tornado-extras is open-sourced.
+    Port of Uber's internal tornado-extras (by @sema).
 
     Tornado's StackContext works as follows:
     - When entering a context, create an instance of StackContext and

--- a/tests/opentracing_instrumentation/test_thread_safe_request_context.py
+++ b/tests/opentracing_instrumentation/test_thread_safe_request_context.py
@@ -1,0 +1,64 @@
+from functools import partial
+
+import time
+
+import pytest
+
+from threading import Thread
+from tornado import gen
+from tornado.locks import Condition
+from tornado.stack_context import wrap
+
+from opentracing_instrumentation.request_context import (
+    get_current_span, span_in_stack_context,
+)
+
+
+def test__request_context_is_thread_safe():
+    """
+    Port of Uber's internal tornado-extras (by @sema).
+
+    This test illustrates that the default Tornado's StackContext
+    is not thread-safe. The test can be made to fail by commenting
+    out these lines in the ThreadSafeStackContext constructor:
+
+        if hasattr(self, 'contexts'):
+            # only patch if context exists
+            self.contexts = LocalContexts()
+    """
+
+    num_iterations = 1000
+    num_workers = 10
+    exception = [0]
+
+    def async_task():
+        time.sleep(0.001)
+        assert get_current_span() is not None
+
+    class Worker(Thread):
+        def __init__(self, fn):
+            super(Worker, self).__init__()
+            self.fn = fn
+
+        def run(self):
+            try:
+                for _ in xrange(0, num_iterations):
+                    self.fn()
+            except Exception as e:
+                exception[0] = e
+                raise
+
+    with span_in_stack_context(span='span'):
+        workers = []
+        for i in xrange(0, num_workers):
+            worker = Worker(wrap(async_task))
+            workers.append(worker)
+
+        for worker in workers:
+            worker.start()
+
+        for worker in workers:
+            worker.join()
+
+    if exception[0]:
+        raise exception[0]

--- a/tests/opentracing_instrumentation/test_thread_safe_request_context.py
+++ b/tests/opentracing_instrumentation/test_thread_safe_request_context.py
@@ -42,7 +42,7 @@ def test__request_context_is_thread_safe():
 
         def run(self):
             try:
-                for _ in xrange(0, num_iterations):
+                for _ in range(0, num_iterations):
                     self.fn()
             except Exception as e:
                 exception[0] = e
@@ -50,7 +50,7 @@ def test__request_context_is_thread_safe():
 
     with span_in_stack_context(span='span'):
         workers = []
-        for i in xrange(0, num_workers):
+        for i in range(0, num_workers):
             worker = Worker(wrap(async_task))
             workers.append(worker)
 


### PR DESCRIPTION
Ported from Uber's internal `tornado-extras` lib. Should've been added in #2.

From internal ticket T233805 by @sema:

> With the help of @recht, I've found a race (or unexpected semantics if you will) in Tornado's StackContext used by tornado-extras' RequestContext.
> 
> In short, StackContext more or less assumes it will only be expected on one thread. If you use it across threads (using wraps) then the context may be entered/exited in unexpected ways. This causes exceptions in RequestContext [like below], and other subtle errors.
> 
> ```
> AttributeError: 'RequestContextManager' object has no attribute '_prev_data'
> ```
> 
> I've included an explanation of the race(s) in the diff + a test case that triggers the error (revert the usage of ThreadSafeStackContext and the test should fail).