### PR TITLE
Fix compatibility with Peewee ORM

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ History
 3.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix compatibility with Peewee ORM (#72) <Aliaksei Urbanski>
 
 
 3.0.1 (2019-04-28)


### PR DESCRIPTION
This patch adds handling for `psycopg2.extensions.register_type`

The original `register_type` method checks a type of the `conn_or_curs` and it doesn't accept wrappers, so we need to make sure that it will not be broken.

Here is a sample traceback:
```bash
$ python demo.py 
Traceback (most recent call last):
  File "demo.py", line 18, in <module>
    psql_db.create_tables([DemoModel])
  File "/home/mim/.local/share/virtualenvs/test-peewee-tracing-QFmnjpzE/lib/python3.7/site-packages/peewee.py", line 3036, in create_tables
    model.create_table(**options)
  File "/home/mim/.local/share/virtualenvs/test-peewee-tracing-QFmnjpzE/lib/python3.7/site-packages/peewee.py", line 6056, in create_table
    and cls.table_exists():
  File "/home/mim/.local/share/virtualenvs/test-peewee-tracing-QFmnjpzE/lib/python3.7/site-packages/peewee.py", line 6046, in table_exists
    return cls._schema.database.table_exists(M.table.__name__, M.schema)
  File "/home/mim/.local/share/virtualenvs/test-peewee-tracing-QFmnjpzE/lib/python3.7/site-packages/peewee.py", line 3014, in table_exists
    return table_name in self.get_tables(schema=schema)
  File "/home/mim/.local/share/virtualenvs/test-peewee-tracing-QFmnjpzE/lib/python3.7/site-packages/peewee.py", line 3489, in get_tables
    cursor = self.execute_sql(query, (schema or 'public',))
  File "/home/mim/.local/share/virtualenvs/test-peewee-tracing-QFmnjpzE/lib/python3.7/site-packages/peewee.py", line 2873, in execute_sql
    cursor = self.cursor(commit)
  File "/home/mim/.local/share/virtualenvs/test-peewee-tracing-QFmnjpzE/lib/python3.7/site-packages/peewee.py", line 2859, in cursor
    self.connect()
  File "/home/mim/.local/share/virtualenvs/test-peewee-tracing-QFmnjpzE/lib/python3.7/site-packages/peewee.py", line 2817, in connect
    self._state.set_connection(self._connect())
  File "/home/mim/.local/share/virtualenvs/test-peewee-tracing-QFmnjpzE/lib/python3.7/site-packages/peewee.py", line 3469, in _connect
    pg_extensions.register_type(pg_extensions.UNICODE, conn)
TypeError: argument 2 must be a connection, cursor or None
```