### PR TITLE
Add Tornado 5 supporting

### DIFF
--- a/opentracing_instrumentation/local_span.py
+++ b/opentracing_instrumentation/local_span.py
@@ -139,7 +139,10 @@ def traced_function(func=None, name=None, on_start=None,
                             span.log(event='exception', payload=exception)
                             span.set_tag('error', 'true')
                         span.finish()
-                    res.add_done_callback(done_callback)
+                    if res.done():
+                        done_callback(res)
+                    else:
+                        res.add_done_callback(done_callback)
                 else:
                     deactivate_cb()
                     span.finish()

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     install_requires=[
         'future',
         'wrapt',
-        'tornado>=4.1,<5',
+        'tornado>=4.1,<6',
         'contextlib2',
         'opentracing>=1.1,<2',
         'six',


### PR DESCRIPTION
In Tornado 5 behavior of `future.add_done_callback` changed a little bit and `done_callback` will be invoked at least on next loop cycle. So we should explicitly finish span if future is done.