### PR TITLE
Added tags.HTTP_METHOD to before_request.

### DIFF
--- a/opentracing_instrumentation/http_server.py
+++ b/opentracing_instrumentation/http_server.py
@@ -52,6 +52,7 @@ def before_request(request, tracer=None):
     tags_dict = {
         tags.SPAN_KIND: tags.SPAN_KIND_RPC_SERVER,
         tags.HTTP_URL: request.full_url,
+        tags.HTTP_METHOD: request.method,
     }
 
     remote_ip = request.remote_ip

--- a/tests/opentracing_instrumentation/test_middleware.py
+++ b/tests/opentracing_instrumentation/test_middleware.py
@@ -46,6 +46,7 @@ def test_middleware(with_peer_tags, with_context):
     :return:
     """
     request = mock.MagicMock()
+    request.method = 'GET'
     request.full_url = 'http://localhost:12345/test'
     request.operation = 'my-test'
     if with_peer_tags:
@@ -71,8 +72,9 @@ def test_middleware(with_peer_tags, with_context):
         extract_call.assert_called_with(
             format=Format.HTTP_HEADERS, carrier={})
         expected_tags = {
+            'http.method': 'GET',
             'http.url': 'http://localhost:12345/test',
-            'span.kind': 'server'
+            'span.kind': 'server',
         }
         if with_peer_tags:
             expected_tags.update({


### PR DESCRIPTION
`tags.HTTP_METHOD` is not set by the HTTP instrumentation. 

Looking on the request wrappers, I couldn't see a reason why this is not there. 