### PR TITLE
@traced_function now works with AsyncIO's coroutines.

### DIFF
--- a/opentracing_instrumentation/local_span.py
+++ b/opentracing_instrumentation/local_span.py
@@ -27,12 +27,12 @@ from . import get_current_span, span_in_stack_context, utils
 try:
     import asyncio
     _ASYNCIO = True
-except Exception:
+except ImportError:
     _ASYNCIO = False
 
 
 def is_asyncio_coroutine(func):
-    return False if not _ASYNCIO else asyncio.iscoroutine(func)
+    return _ASYNCIO and asyncio.iscoroutine(func)
 
 
 def func_span(func, tags=None, require_active_trace=False):


### PR DESCRIPTION
When using Tornado 5 it's common to start migrating to `async/await` syntaxes.

However, @traced_function only understands Tornado's Futures but not necessarily AsyncIO coroutines.

This PR adds supports to it without breaking compatibility with older versions of Python.