### PR TITLE
Add support for Celery

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,37 @@
 dist: xenial
+addons:
+  apt:
+    packages:
+      - rabbitmq-server
 sudo: true
 
 language: python
+python:
+  - '2.7'
+  - '3.4'
+  - '3.5'
+  - '3.6'
+
+env:
+  matrix:
+    - CELERY=3
+    - CELERY=4
 
 matrix:
   include:
-  - python: '2.7'
-    env: COVER=1
-  - python: '3.4'
-    dist: trusty
-  - python: '3.5'
-  - python: '3.6'
   - python: '3.7'
+    env:
+      CELERY=4 COVER=1
 
 install:
   - make install-ci
+  - pip install celery~=${CELERY}.0
 
 services:
   - docker
   - postgresql
-  - redis
+  - rabbitmq
+  - redis-server
 
 before_script:
   - docker-compose up -d dynamodb

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ The module name is `opentracing_instrumentation`.
 
 The following libraries are instrumented for tracing in this module:
  * [boto3](https://github.com/boto/boto3) — AWS SDK for Python
+ * [Celery](https://github.com/celery/celery) — Distributed Task Queue
  * `urllib2`
  * `requests`
  * `SQLAlchemy`
@@ -219,7 +220,8 @@ install_all_patches()
 
 ## Development
 
-`PostgreSQL`, `Redis` and `DynamoDB` are required for certain tests.
+`PostgreSQL`, `RabbitMQ`, `Redis`, and `DynamoDB`
+are required for certain tests.
 ```bash
 docker-compose up -d
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,11 @@
 version: "3"
 
 services:
+  rabbitmq:
+    image: rabbitmq
+    ports:
+      - "5672:5672"
+
   redis:
     image: redis
     ports:

--- a/opentracing_instrumentation/client_hooks/__init__.py
+++ b/opentracing_instrumentation/client_hooks/__init__.py
@@ -37,6 +37,7 @@ def install_all_patches():
     If a specific module is not available on the path, it is ignored.
     """
     from . import boto3
+    from . import celery
     from . import mysqldb
     from . import psycopg2
     from . import strict_redis
@@ -47,6 +48,7 @@ def install_all_patches():
     from . import requests
 
     boto3.install_patches()
+    celery.install_patches()
     mysqldb.install_patches()
     psycopg2.install_patches()
     strict_redis.install_patches()

--- a/opentracing_instrumentation/client_hooks/celery.py
+++ b/opentracing_instrumentation/client_hooks/celery.py
@@ -1,0 +1,128 @@
+from __future__ import absolute_import
+
+import opentracing
+from opentracing.ext import tags
+
+from ..request_context import get_current_span, span_in_context
+from ._patcher import Patcher
+
+
+try:
+    from celery.app.task import Task
+    from celery.signals import (
+        before_task_publish, task_prerun, task_success, task_failure
+    )
+except ImportError:  # pragma: no cover
+    pass
+else:
+    _task_apply_async = Task.apply_async
+
+
+def task_apply_async_wrapper(task, args=None, kwargs=None, **other_kwargs):
+    operation_name = 'Celery:apply_async:{}'.format(task.name)
+    span = opentracing.tracer.start_span(operation_name=operation_name,
+                                         child_of=get_current_span())
+    set_common_tags(span, task, tags.SPAN_KIND_RPC_CLIENT)
+
+    with span_in_context(span), span:
+        result = _task_apply_async(task, args, kwargs, **other_kwargs)
+        span.set_tag('celery.task_id', result.task_id)
+        return result
+
+
+def set_common_tags(span, task, span_kind):
+    span.set_tag(tags.SPAN_KIND, span_kind)
+    span.set_tag(tags.COMPONENT, 'Celery')
+    span.set_tag('celery.task_name', task.name)
+
+
+def before_task_publish_handler(headers, **kwargs):
+    headers['parent_span_context'] = span_context = {}
+    opentracing.tracer.inject(span_context=get_current_span().context,
+                              format=opentracing.Format.TEXT_MAP,
+                              carrier=span_context)
+
+
+def task_prerun_handler(task, task_id, **kwargs):
+    request = task.request
+
+    operation_name = 'Celery:run:{}'.format(task.name)
+    child_of = None
+    if request.delivery_info.get('is_eager'):
+        child_of = get_current_span()
+    else:
+        if hasattr(request, 'headers'):
+            # Celery 3.x
+            parent_span_context = (
+                request.headers and request.headers.get('parent_span_context')
+            )
+        else:
+            # Celery 4.x
+            parent_span_context = getattr(request, 'parent_span_context', None)
+
+        if parent_span_context:
+            child_of = opentracing.tracer.extract(
+                opentracing.Format.TEXT_MAP, parent_span_context
+            )
+
+    task.request.span = span = opentracing.tracer.start_span(
+        operation_name=operation_name,
+        child_of=child_of,
+    )
+    set_common_tags(span, task, tags.SPAN_KIND_RPC_SERVER)
+    span.set_tag('celery.task_id', task_id)
+
+    request.tracing_context = span_in_context(span)
+    request.tracing_context.__enter__()
+
+
+def finish_current_span(task, exc_type=None, exc_val=None, exc_tb=None):
+    task.request.span.finish()
+    task.request.tracing_context.__exit__(exc_type, exc_val, exc_tb)
+
+
+def task_success_handler(sender, **kwargs):
+    finish_current_span(task=sender)
+
+
+def task_failure_handler(sender, exception, traceback, **kwargs):
+    finish_current_span(
+        task=sender,
+        exc_type=type(exception),
+        exc_val=exception,
+        exc_tb=traceback,
+    )
+
+
+class CeleryPatcher(Patcher):
+    applicable = '_task_apply_async' in globals()
+
+    def _install_patches(self):
+        Task.apply_async = task_apply_async_wrapper
+        before_task_publish.connect(before_task_publish_handler)
+        task_prerun.connect(task_prerun_handler)
+        task_success.connect(task_success_handler)
+        task_failure.connect(task_failure_handler)
+
+    def _reset_patches(self):
+        Task.apply_async = _task_apply_async
+        before_task_publish.disconnect(before_task_publish_handler)
+        task_prerun.disconnect(task_prerun_handler)
+        task_success.disconnect(task_success_handler)
+        task_failure.disconnect(task_failure_handler)
+
+
+patcher = CeleryPatcher()
+
+
+def set_patcher(custom_patcher):
+    global patcher
+    patcher = custom_patcher
+
+
+def install_patches():
+    patcher.install_patches()
+
+
+def reset_patches():
+    patcher.reset_patches()

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
         'tests': [
             'boto3',
             'botocore',
+            'celery',
             'coveralls',
             'doubles',
             'flake8',

--- a/tests/opentracing_instrumentation/test_celery.py
+++ b/tests/opentracing_instrumentation/test_celery.py
@@ -1,0 +1,175 @@
+import celery as celery_module
+import mock
+import pytest
+
+from celery import Celery
+from celery.signals import after_task_publish, task_prerun, task_postrun
+from celery.states import SUCCESS, FAILURE
+from kombu import Connection
+from opentracing.ext import tags
+
+from opentracing_instrumentation.client_hooks import celery as celery_hooks
+
+
+@pytest.fixture(autouse=True, scope='module')
+def patch_celery():
+    celery_hooks.install_patches()
+    try:
+        yield
+    finally:
+        celery_hooks.reset_patches()
+
+
+def assert_span(span, result, operation, span_kind):
+    assert span.operation_name == 'Celery:{}:foo'.format(operation)
+    assert span.tags.get(tags.SPAN_KIND) == span_kind
+    assert span.tags.get(tags.COMPONENT) == 'Celery'
+    assert span.tags.get('celery.task_name') == 'foo'
+    assert span.tags.get('celery.task_id') == result.task_id
+
+
+def _test_foo_task(celery, task_error):
+
+    @celery.task(name='foo')
+    def foo():
+        foo.called = True
+        if task_error:
+            raise ValueError('Task error')
+    foo.called = False
+
+    result = foo.delay()
+    assert foo.called
+    if task_error:
+        assert result.status == FAILURE
+    else:
+        assert result.status == SUCCESS
+
+    return result
+
+
+def _test(celery, tracer, task_error):
+    result = _test_foo_task(celery, task_error)
+
+    span_server, span_client = tracer.recorder.get_spans()
+    assert span_client.parent_id is None
+    assert span_client.context.trace_id == span_server.context.trace_id
+    assert span_client.context.span_id == span_server.parent_id
+
+    assert_span(span_client, result, 'apply_async', tags.SPAN_KIND_RPC_CLIENT)
+    assert_span(span_server, result, 'run', tags.SPAN_KIND_RPC_SERVER)
+
+
+def is_rabbitmq_running():
+    try:
+        Connection('amqp://guest:guest@127.0.0.1:5672//').connect()
+        return True
+    except:
+        return False
+
+
+@pytest.mark.skipif(not is_rabbitmq_running(),
+                    reason='RabbitMQ is not running or cannot connect')
+@pytest.mark.parametrize('task_error', (False, True))
+def test_celery_with_rabbitmq(tracer, task_error):
+    celery = Celery(
+        'test',
+
+        # For Celery 3.x we have to use rpc:// to get the results
+        # because with Redis we can get only PENDING for the status.
+        # For Celery 4.x we need redis:// since with RPC we can
+        # correctly assert status only for the first one task.
+        # Feel free to suggest a better solution here.
+        backend=(
+            'rpc://'
+            if celery_module.__version__.split('.', 1)[0] == '3' else
+            'redis://'
+        ),
+
+        # avoiding CDeprecationWarning
+        changes={
+            'CELERY_ACCEPT_CONTENT': ['pickle', 'json'],
+        }
+    )
+
+    @after_task_publish.connect
+    def run_worker(**kwargs):
+        after_task_publish.disconnect(run_worker)
+        worker = celery.Worker(concurrency=1,
+                               pool_cls='solo',
+                               use_eventloop=False,
+                               prefetch_multiplier=1,
+                               quiet=True,
+                               without_heartbeat=True)
+
+        @task_postrun.connect
+        def stop_worker_soon(**kwargs):
+            task_postrun.disconnect(stop_worker_soon)
+            if hasattr(worker.consumer, '_pending_operations'):
+                # Celery 4.x
+
+                def stop_worker():
+                    # avoiding AttributeError that makes tests noisy
+                    worker.consumer.connection.drain_events = mock.Mock()
+
+                    worker.stop()
+
+                # worker must be stopped not earlier than
+                # data exchange with RabbitMQ is completed
+                worker.consumer._pending_operations.insert(0, stop_worker)
+            else:
+                # Celery 3.x
+                worker.stop()
+
+        worker.start()
+
+    _test(celery, tracer, task_error)
+
+
+@pytest.fixture
+def celery_eager():
+    celery = Celery('test')
+    celery.config_from_object({
+        'task_always_eager': True,  # Celery 4.x
+        'CELERY_ALWAYS_EAGER': True,  # Celery 3.x
+    })
+    return celery
+
+
+@pytest.mark.parametrize('task_error', (False, True))
+def test_celery_eager(celery_eager, tracer, task_error):
+    _test(celery_eager, tracer, task_error)
+
+
+@pytest.mark.parametrize('task_error', (False, True))
+@mock.patch('opentracing_instrumentation.client_hooks.celery.span_in_context')
+def test_celery_run_without_parent_span(span_in_context_mock, celery_eager,
+                                        tracer, task_error):
+
+    def task_prerun_hook(task, **kwargs):
+        task.request.delivery_info['is_eager'] = False
+
+    task_prerun.connect(task_prerun_hook)
+    task_prerun.receivers = list(reversed(task_prerun.receivers))
+    try:
+        result = _test_foo_task(celery_eager, task_error)
+    finally:
+        task_prerun.disconnect(task_prerun_hook)
+
+    span_server = tracer.recorder.get_spans()[0]
+    assert span_server.parent_id is None
+    assert_span(span_server, result, 'run', tags.SPAN_KIND_RPC_SERVER)
+
+
+@mock.patch.object(celery_hooks, 'patcher')
+def test_set_custom_patcher(default_patcher):
+    patcher = mock.Mock()
+    celery_hooks.set_patcher(patcher)
+
+    assert celery_hooks.patcher is not default_patcher
+    assert celery_hooks.patcher is patcher
+
+    celery_hooks.install_patches()
+    celery_hooks.reset_patches()
+
+    patcher.install_patches.assert_called_once()
+    patcher.reset_patches.assert_called_once()

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,12 @@
 [tox]
-envlist = py27,py34,py35,py36,py37
+envlist = py{27,34,35,36}-celery{3,4},py37-celery4
+skip_missing_interpreters = true
 
 [testenv]
-install_command = pip install {opts} {packages} {env:PWD}[tests]
+deps =
+    celery3: celery~=3.0
+    celery4: celery~=4.0
+extras = tests
 commands =
     flake8
     pytest


### PR DESCRIPTION
Hi @yurishkuro,

I believe that it would be great to have support for [Celery](https://github.com/celery/celery) in the upstream of `opentracing_instrumentation`.

Celery's PyPI Stats:
https://pypistats.org/packages/celery

Hello @auvipy and @thedrow,
I suppose this PR might be interesting for you.

Cheers!