### PR TITLE
Support non TornadoScopeManager in traced_function decorator

### DIFF
--- a/opentracing_instrumentation/request_context.py
+++ b/opentracing_instrumentation/request_context.py
@@ -178,22 +178,6 @@ def span_in_context(span):
     return opentracing.tracer.scope_manager.activate(span, False)
 
 
-class _DummyStackContext(object):
-    """
-    Stack context that will be used in `span_in_stack_context` when tracer
-    scope manager is not `TornadoScopeManager`.
-    """
-
-    def __enter__(self):
-        self._current_context = opentracing.tracer.scope_manager.active
-        return lambda: None
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        if opentracing.tracer.scope_manager.active:
-            opentracing.tracer.scope_manager.active.close()
-        assert self._current_context == opentracing.tracer.scope_manager.active
-
-
 def span_in_stack_context(span):
     """
     Create Tornado's StackContext that stores the given span in the
@@ -224,17 +208,14 @@ def span_in_stack_context(span):
         Return StackContext that wraps the request context.
     """
 
-    if isinstance(opentracing.tracer.scope_manager, TornadoScopeManager):
-        # Use custom Tornado stack context that correctly stores and restores
-        # coroutine context.
-        context = tracer_stack_context()
-    else:
-        # Fallback to "dummy" context if it's not a `TornadoScopeManager` which
-        # will restore previous scope after exit.
-        context = _DummyStackContext()
+    if not isinstance(opentracing.tracer.scope_manager, TornadoScopeManager):
+        raise RuntimeError('scope_manager is not TornadoScopeManager')
+
     # Enter the newly created stack context so we have
     # storage available for Span activation.
+    context = tracer_stack_context()
     entered_context = _TracerEnteredStackContext(context)
+
     if span is None:
         return entered_context
 

--- a/tests/opentracing_instrumentation/test_traced_function_decorator.py
+++ b/tests/opentracing_instrumentation/test_traced_function_decorator.py
@@ -21,11 +21,14 @@
 from __future__ import absolute_import
 from builtins import object
 import mock
+import unittest
 import opentracing
+from opentracing.mocktracer import MockTracer
 from opentracing.scope_managers.tornado import TornadoScopeManager
+from opentracing.scope_managers import ThreadLocalScopeManager
 
 import tornado.stack_context
-import tornado.concurrent
+from tornado.concurrent import is_future
 from tornado import gen
 from tornado.testing import AsyncTestCase, gen_test
 from opentracing_instrumentation import traced_function
@@ -39,30 +42,189 @@ def extract_call_site_tag(span, *_, **kwargs):
         span.set_tag('call_site_tag', kwargs['call_site_tag'])
 
 
-@mock.patch('opentracing.tracer', opentracing.Tracer(TornadoScopeManager()))
-class TracedFuctionDecoratorTest(AsyncTestCase):
+class Client(object):
+
+    def _func(self, param):
+        assert param == 123
+        return 'oh yeah'
+
+    @traced_function
+    def regular(self, param):
+        return self._func(param)
+
+    @traced_function(name='some_name')
+    def regular_with_name(self, param):
+        return self._func(param)
+
+    @traced_function(on_start=extract_call_site_tag)
+    def regular_with_hook(self, param1, param2=None, call_site_tag=None):
+        assert param1 == call_site_tag
+        assert param2 is None
+        return 'oh yeah'
+
+    @traced_function(require_active_trace=True)
+    def regular_require_active_trace(self, param):
+        return self._func(param)
+
+    def _coro(self, param):
+        return tornado.gen.Return(self._func(param))
+
+    @traced_function
+    @gen.coroutine
+    def coro(self, param):
+        raise self._coro(param)
+
+    @traced_function(name='some_name')
+    @gen.coroutine
+    def coro_with_name(self, param):
+        raise self._coro(param)
+
+    @traced_function(on_start=extract_call_site_tag)
+    @gen.coroutine
+    def coro_with_hook(self, param1, param2=None, call_site_tag=None):
+        assert param1 == call_site_tag
+        assert param2 is None
+        raise tornado.gen.Return('oh yeah')
+
+    @traced_function(require_active_trace=True)
+    def coro_require_active_trace(self, param):
+        raise self._coro(param)
+
+
+class PrepareMixin(object):
+
+    scope_manager = None
+
+    def setUp(self):
+        super(PrepareMixin, self).setUp()
+        self.patcher = mock.patch(
+            'opentracing.tracer', MockTracer(self.scope_manager()))
+        self.patcher.start()
+        self.client = Client()
+
+    def tearDown(self):
+        super(PrepareMixin, self).tearDown()
+        self.patcher.stop()
+
+
+class TracedRegularFunctionDecoratorTest(PrepareMixin, unittest.TestCase):
+
+    scope_manager = ThreadLocalScopeManager
+
+    def test_no_arg_decorator(self):
+
+        parent = opentracing.tracer.start_span('hello')
+
+        with opentracing.tracer.scope_manager.activate(parent, True) as scope:
+            child = mock.MagicMock()
+            # verify start_child is called with actual function name
+            with patch_object(opentracing.tracer, 'start_span',
+                              return_value=child) as start_child:
+                child.set_tag = mock.MagicMock()
+                child.error = mock.MagicMock()
+                child.finish = mock.MagicMock()
+                r = self.client.regular(123)
+                start_child.assert_called_once_with(
+                    operation_name='regular',
+                    child_of=parent.context,
+                    tags=None)
+                assert child.set_tag.call_count == 0
+                assert child.error.call_count == 0
+                assert child.finish.call_count == 1
+                assert r == 'oh yeah'
+
+            # verify span.error() is called on exception
+            child = mock.MagicMock()
+            with patch_object(opentracing.tracer, 'start_span') as start_child:
+                start_child.return_value = child
+                child.error = mock.MagicMock()
+                child.finish = mock.MagicMock()
+                with self.assertRaises(AssertionError):
+                    self.client.regular(999)
+                assert child.log.call_count == 1
+                assert child.finish.call_count == 1
+        scope.close()
+
+    def test_decorator_with_name(self):
+
+        parent = opentracing.tracer.start_span('hello')
+
+        with opentracing.tracer.scope_manager.activate(parent, True) as scope:
+            child = mock.MagicMock()
+            with patch_object(opentracing.tracer, 'start_span',
+                              return_value=child) as start_child:
+                child.set_tag = mock.MagicMock()
+                r = self.client.regular_with_name(123)
+                assert r == 'oh yeah'
+                start_child.assert_called_once_with(
+                    operation_name='some_name',  # overridden name
+                    child_of=parent.context,
+                    tags=None)
+                assert child.set_tag.call_count == 0
+            parent.finish()
+        scope.close()
+
+    def test_decorator_with_start_hook(self):
+
+        parent = opentracing.tracer.start_span('hello')
+
+        with opentracing.tracer.scope_manager.activate(parent, True) as scope:
+            # verify call_size_tag argument is extracted and added as tag
+            child = mock.MagicMock()
+            with patch_object(opentracing.tracer, 'start_span') \
+                    as start_child:
+                start_child.return_value = child
+                child.set_tag = mock.MagicMock()
+                r = self.client.regular_with_hook(
+                    'somewhere', call_site_tag='somewhere')
+                assert r == 'oh yeah'
+                start_child.assert_called_once_with(
+                    operation_name='regular_with_hook',
+                    child_of=parent.context,
+                    tags=None)
+                child.set_tag.assert_called_once_with(
+                    'call_site_tag', 'somewhere')
+        scope.close()
+
+    def test_no_parent_span(self):
+
+        with patch_object(opentracing.tracer, 'start_span') as start:
+            r = self.client.regular(123)
+            assert r == 'oh yeah'
+            start.assert_called_once_with(
+                operation_name='regular', child_of=None, tags=None)
+
+        # verify no new trace or child span is started
+        with patch_object(opentracing.tracer, 'start_span') as start:
+            r = self.client.regular_require_active_trace(123)
+            assert r == 'oh yeah'
+            assert start.call_count == 0
+
+
+class TracedCoroFunctionDecoratorTest(PrepareMixin, AsyncTestCase):
+
+    scope_manager = TornadoScopeManager
+
+    @gen.coroutine
+    def call(self, method, *args, **kwargs):
+        """
+        Execute synchronous or asynchronous method of client and return the
+        result.
+        """
+        result = getattr(self.client, method)(*args, **kwargs)
+        if is_future(result):
+            result = yield result
+        raise tornado.gen.Return(result)
 
     @gen_test
     def test_no_arg_decorator(self):
-        class SomeClient(object):
-            @traced_function
-            @gen.coroutine
-            def func1(self, param1):
-                assert param1 == 123
-                raise tornado.gen.Return('oh yeah')
 
-            @traced_function
-            def func1_1(self, param1):
-                assert param1 == 123
-                return 'oh yeah'  # not a co-routine
-
-        s = SomeClient()
         parent = opentracing.tracer.start_span('hello')
 
         @gen.coroutine
         def run():
             # test both co-routine and regular function
-            for func in ['func1', 'func1_1']:
+            for func in ('regular', 'coro', ):
                 child = mock.MagicMock()
                 # verify start_child is called with actual function name
                 with patch_object(opentracing.tracer, 'start_span',
@@ -70,10 +232,7 @@ class TracedFuctionDecoratorTest(AsyncTestCase):
                     child.set_tag = mock.MagicMock()
                     child.error = mock.MagicMock()
                     child.finish = mock.MagicMock()
-                    if func == 'func1':
-                        r = yield s.func1(123)
-                    else:
-                        r = s.func1_1(123)
+                    r = yield self.call(func, 123)
                     start_child.assert_called_once_with(
                         operation_name=func,
                         child_of=parent.context,
@@ -91,10 +250,7 @@ class TracedFuctionDecoratorTest(AsyncTestCase):
                     child.error = mock.MagicMock()
                     child.finish = mock.MagicMock()
                     with self.assertRaises(AssertionError):
-                        if func == 'func1':
-                            yield s.func1(999)
-                        else:
-                            s.func1_1(999)
+                        yield self.call(func, 999)
                     assert child.log.call_count == 1
                     assert child.finish.call_count == 1
 
@@ -104,99 +260,76 @@ class TracedFuctionDecoratorTest(AsyncTestCase):
 
     @gen_test
     def test_decorator_with_name(self):
-        class SomeClient(object):
-            @traced_function(name='func2_modified')
-            @gen.coroutine
-            def func2(self, param1):
-                assert param1 == 123
-                raise tornado.gen.Return('oh yeah')
 
-        s = SomeClient()
         parent = opentracing.tracer.start_span('hello')
 
         @gen.coroutine
         def run():
             # verify start_span is called with overridden function name
-            child = mock.MagicMock()
-            with patch_object(opentracing.tracer, 'start_span',
-                              return_value=child) as start_child:
-                child.set_tag = mock.MagicMock()
-                r = yield s.func2(123)
-                assert r == 'oh yeah'
-                start_child.assert_called_once_with(
-                    operation_name='func2_modified',  # overridden name
-                    child_of=parent.context,
-                    tags=None)
-                assert child.set_tag.call_count == 0
+            for func in ('regular_with_name', 'coro_with_name', ):
+                child = mock.MagicMock()
+                with patch_object(opentracing.tracer, 'start_span',
+                                  return_value=child) as start_child:
+                    child.set_tag = mock.MagicMock()
+                    r = yield self.call(func, 123)
+                    assert r == 'oh yeah'
+                    start_child.assert_called_once_with(
+                        operation_name='some_name',  # overridden name
+                        child_of=parent.context,
+                        tags=None)
+                    assert child.set_tag.call_count == 0
 
-            raise tornado.gen.Return(1)
+                raise tornado.gen.Return(1)
 
         yield run_coroutine_with_span(span=parent, coro=run)
 
     @gen_test
     def test_decorator_with_start_hook(self):
-        class SomeClient(object):
-            @traced_function(on_start=extract_call_site_tag)
-            def func3(self, param1, param2=None, call_site_tag=None):
-                assert param1 == call_site_tag
-                assert param2 is None
-                return 'oh yeah'  # not a co-routine
 
-        s = SomeClient()
         parent = opentracing.tracer.start_span('hello')
 
         @gen.coroutine
         def run():
             # verify call_size_tag argument is extracted and added as tag
-            child = mock.MagicMock()
-            with patch_object(opentracing.tracer, 'start_span') \
-                    as start_child:
-                start_child.return_value = child
-                child.set_tag = mock.MagicMock()
-                r = s.func3('somewhere', call_site_tag='somewhere')
-                assert r == 'oh yeah'
-                start_child.assert_called_once_with(
-                    operation_name='func3',
-                    child_of=parent.context,
-                    tags=None)
-                child.set_tag.assert_called_once_with(
-                    'call_site_tag', 'somewhere')
+            for func in ('regular_with_hook', 'coro_with_hook', ):
+                child = mock.MagicMock()
+                with patch_object(opentracing.tracer, 'start_span') \
+                        as start_child:
+                    start_child.return_value = child
+                    child.set_tag = mock.MagicMock()
+                    r = yield self.call(
+                        func, 'somewhere', call_site_tag='somewhere')
+                    assert r == 'oh yeah'
+                    start_child.assert_called_once_with(
+                        operation_name='regular_with_hook',
+                        child_of=parent.context,
+                        tags=None)
+                    child.set_tag.assert_called_once_with(
+                        'call_site_tag', 'somewhere')
 
-            raise tornado.gen.Return(1)
+                raise tornado.gen.Return(1)
 
         yield run_coroutine_with_span(span=parent, coro=run)
 
     @gen_test
     def test_no_parent_span(self):
-        class SomeClient(object):
-            @traced_function
-            def func4(self, param1):
-                assert param1 == 123
-                return 'oh yeah'  # not a co-routine
-
-        class SomeClient2(object):
-            @traced_function(require_active_trace=True)
-            def func5(self, param1):
-                assert param1 == 123
-                return 'oh yeah'  # not a co-routine
-
-        s = SomeClient()
-        s2 = SomeClient2()
 
         @gen.coroutine
         def run():
             # verify a new trace is started
-            with patch_object(opentracing.tracer, 'start_span') as start:
-                r = s.func4(123)
-                assert r == 'oh yeah'
-                start.assert_called_once_with(
-                    operation_name='func4', child_of=None, tags=None)
+            for func1, func2 in (('regular', 'regular_require_active_trace'),
+                                 ('coro', 'coro_require_active_trace')):
+                with patch_object(opentracing.tracer, 'start_span') as start:
+                    r = yield self.call(func1, 123)
+                    assert r == 'oh yeah'
+                    start.assert_called_once_with(
+                        operation_name=func1, child_of=None, tags=None)
 
-            # verify no new trace or child span is started
-            with patch_object(opentracing.tracer, 'start_span') as start:
-                r = s2.func5(123)
-                assert r == 'oh yeah'
-                assert start.call_count == 0
+                # verify no new trace or child span is started
+                with patch_object(opentracing.tracer, 'start_span') as start:
+                    r = yield self.call(func2, 123)
+                    assert r == 'oh yeah'
+                    assert start.call_count == 0
 
             raise tornado.gen.Return(1)
 
@@ -209,7 +342,7 @@ def run_coroutine_with_span(span, coro, *args, **kwargs):
     This makes the span available through the get_current_span() function.
 
     :param span: The tracing span to expose.
-    :param func: Co-routine to execute in the scope of tracing span.
+    :param coro: Co-routine to execute in the scope of tracing span.
     :param args: Positional args to func, if any.
     :param kwargs: Keyword args to func, if any.
     """

--- a/tests/opentracing_instrumentation/test_traced_function_decorator.py
+++ b/tests/opentracing_instrumentation/test_traced_function_decorator.py
@@ -279,7 +279,7 @@ class TracedCoroFunctionDecoratorTest(PrepareMixin, AsyncTestCase):
                         tags=None)
                     assert child.set_tag.call_count == 0
 
-                raise tornado.gen.Return(1)
+            raise tornado.gen.Return(1)
 
         yield run_coroutine_with_span(span=parent, coro=run)
 
@@ -301,13 +301,13 @@ class TracedCoroFunctionDecoratorTest(PrepareMixin, AsyncTestCase):
                         func, 'somewhere', call_site_tag='somewhere')
                     assert r == 'oh yeah'
                     start_child.assert_called_once_with(
-                        operation_name='regular_with_hook',
+                        operation_name=func,
                         child_of=parent.context,
                         tags=None)
                     child.set_tag.assert_called_once_with(
                         'call_site_tag', 'somewhere')
 
-                raise tornado.gen.Return(1)
+            raise tornado.gen.Return(1)
 
         yield run_coroutine_with_span(span=parent, coro=run)
 


### PR DESCRIPTION
Fix https://github.com/uber-common/opentracing-python-instrumentation/issues/80