### PR TITLE
Fix coveralls/boto3 dependency conflict

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,10 +41,13 @@ setup(
     ],
     extras_require={
         'tests': [
+            # coveralls should be required before boto3
+            # to avoid dependency conflict for Python 2.7
+            'coveralls',
+
             'boto3',
             'botocore',
             'celery',
-            'coveralls',
             'doubles',
             'flake8',
             'flake8-quotes',
@@ -52,11 +55,7 @@ setup(
             'moto',
             'psycopg2-binary',
             'sqlalchemy>=1.2.0',
-
-            # pytest-tornado isn't compatible with pytest>=4.0.0,
-            # see https://github.com/eugeniy/pytest-tornado/pull/38
-            'pytest>=3.0.0,<4.0.0',
-
+            'pytest',
             'pytest-cov',
             'pytest-localserver',
             'pytest-mock',


### PR DESCRIPTION
Both `coveralls` and `boto3` require `urllib3`.
But for Python 2.7 `coveralls` requires `urllib3[secure]<1.25,>=1.21.1` when `boto3` requires `botocore` which requires `urllib3>=1.20,<1.26`.

`pip` installs version that's required first because it has no dependency resolver.
See pypa/pip#988 for details.

So we have to move `coveralls` upper to fix the issue.

Fixes #91

These changes also:
 - Unpin `pytest`