### PR TITLE
remove support for python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ sudo: true
 language: python
 python:
   - '2.7'
-  - '3.4'
   - '3.5'
   - '3.6'
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ History
 3.1.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Removed support for Python 3.4
 
 
 3.1.1 (2019-07-05)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![PyPI version][pypi-img]][pypi] [![Build Status][ci-img]][ci] [![Coverage Status][cov-img]][cov]
+[![PyPI version][pypi-img]][pypi] [![Python versions][pyver-img]][pypi] [![Pypi Downloads][pydl-img]][pypi] [![Build Status][ci-img]][ci] [![Coverage Status][cov-img]][cov] 
+
 
 # opentracing-python-instrumentation
 
@@ -245,3 +246,5 @@ tox
 [pypi]: https://pypi.python.org/pypi/opentracing_instrumentation
 [cov-img]: https://coveralls.io/repos/github/uber-common/opentracing-python-instrumentation/badge.svg
 [cov]: https://coveralls.io/github/uber-common/opentracing-python-instrumentation
+[pyver-img]: https://img.shields.io/pypi/pyversions/opentracing-instrumentation.svg 
+[pydl-img]: https://img.shields.io/pypi/dm/opentracing-instrumentation.svg 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,34,35,36}-celery{3,4},py37-celery4
+envlist = py{27,35,36}-celery{3,4},py37-celery4
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
Also add a couple more badges to README

Python 3.4 is [EOL](https://devguide.python.org/devcycle/#end-of-life-branches)