### PR TITLE
Fix span context propagation for Celery

### DIFF
--- a/opentracing_instrumentation/client_hooks/celery.py
+++ b/opentracing_instrumentation/client_hooks/celery.py
@@ -51,11 +51,9 @@ def task_prerun_handler(task, task_id, **kwargs):
     if request.delivery_info.get('is_eager'):
         child_of = get_current_span()
     else:
-        if hasattr(request, 'headers'):
+        if getattr(request, 'headers', None) is not None:
             # Celery 3.x
-            parent_span_context = (
-                request.headers and request.headers.get('parent_span_context')
-            )
+            parent_span_context = request.headers.get('parent_span_context')
         else:
             # Celery 4.x
             parent_span_context = getattr(request, 'parent_span_context', None)

--- a/tox.ini
+++ b/tox.ini
@@ -10,4 +10,4 @@ deps =
 extras = tests
 commands =
     flake8
-    pytest --cov=opentracing_instrumentation
+    pytest --cov=opentracing_instrumentation --cov-append


### PR DESCRIPTION
Hello @yurishkuro,

I found that for Celery 4 a `request` still has the `headers` attribute, so we have to check if it is not `None`.
Using `getattr` in case `headers` will be removed in the future.

These changes also:
 - Remove `test_celery_run_without_parent_span` in favor of `_test_with_regular_client`
 - Fix stopping of Celery 3 test workers
 - Add `--cov-append` in order to have more precise coverage reports.
   Currently, for each Travis CI job we have coverage for the last tox run only
   (for tests with Celery 4, not with Celery 3).