### PR TITLE
Improve support for Boto 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,16 +23,25 @@ services:
   - redis-server
 
 before_script:
-  - docker-compose up -d dynamodb
+  - docker-compose up -d localstack
   - mysql -e 'CREATE DATABASE test;'
   - psql -c 'CREATE DATABASE test;' -U postgres
 
-  # waiting for DynamoDB
-  - while [[ $(curl -so /dev/null -w '%{response_code}' localhost:8000) != '400' ]]; do sleep 1; done
+  # waiting for the DynamoDB mock
+  - |
+    while [[ $(curl -so /dev/null -w '%{response_code}' localhost:4569) != '502' ]]
+    do
+        echo 'waiting 1 sec for DynamoDB...'
+        sleep 1
+    done
 
-  # workaround for Travis CI issue #7940
-  # https://github.com/travis-ci/travis-ci/issues/7940
-  - sudo rm -f /etc/boto.cfg
+  # waiting for the S3 mock
+  - |
+    while [[ $(curl -so /dev/null -w '%{response_code}' localhost:4572) != '200' ]]
+    do
+        echo 'waiting 1 sec for S3...'
+        sleep 1
+    done
 
 script:
   - tox

--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ The following libraries are instrumented for tracing in this module:
  * Tornado HTTP client
  *  `redis`
 
+#### Limitations
+
+For some operations, `Boto3` uses `ThreadPoolExecutor` under the hood.
+So, in order to make it thread-safe, the instrumentation is implemented using
+`span_in_stack_context()` which
+[forces you](https://github.com/uber-common/opentracing-python-instrumentation#in-process-context-propagation)
+to use `TornadoScopeManager`.
+
 ### Server instrumentation
 
 For inbound requests a helper function `before_request` is provided for creating middleware for frameworks like Flask and uWSGI.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,7 +26,10 @@ services:
     ports:
       - "3306:3306"
 
-  dynamodb:
-    image: amazon/dynamodb-local
+  localstack:
+    image: localstack/localstack
+    environment:
+      - SERVICES=dynamodb,s3
     ports:
-      - "8000:8000"
+      - "4569:4569"  # DynamoDB
+      - "4572:4572"  # S3

--- a/opentracing_instrumentation/client_hooks/boto3.py
+++ b/opentracing_instrumentation/client_hooks/boto3.py
@@ -1,30 +1,65 @@
 from __future__ import absolute_import
+import logging
 
 from opentracing.ext import tags
+from tornado.stack_context import wrap as keep_stack_context
 
 from opentracing_instrumentation import utils
-from ..request_context import get_current_span
+from ..request_context import get_current_span, span_in_stack_context
 from ._patcher import Patcher
 
 
 try:
     from boto3.resources.action import ServiceAction
+    from boto3.s3 import inject as s3_functions
     from botocore import xform_name
+    from botocore.client import BaseClient
     from botocore.exceptions import ClientError
+    from s3transfer.futures import BoundedExecutor
 except ImportError:  # pragma: no cover
     pass
 else:
     _service_action_call = ServiceAction.__call__
+    _client_make_api_call = BaseClient._make_api_call
+    _Executor = BoundedExecutor.EXECUTOR_CLS
+
+logger = logging.getLogger(__name__)
 
 
 class Boto3Patcher(Patcher):
     applicable = '_service_action_call' in globals()
 
+    S3_FUNCTIONS_TO_INSTRUMENT = (
+        'copy',
+        'download_file',
+        'download_fileobj',
+        'upload_file',
+        'upload_fileobj',
+    )
+
+    def __init__(self):
+        super(Boto3Patcher, self).__init__()
+        self.s3_original_funcs = {}
+
     def _install_patches(self):
-        ServiceAction.__call__ = self._get_call_wrapper()
+        ServiceAction.__call__ = self._get_service_action_call_wrapper()
+        BaseClient._make_api_call = self._get_client_make_api_call_wrapper()
+        BoundedExecutor.EXECUTOR_CLS = self._get_instrumented_executor_cls()
+        for func_name in self.S3_FUNCTIONS_TO_INSTRUMENT:
+            func = getattr(s3_functions, func_name, None)
+            if func:
+                self.s3_original_funcs[func_name] = func
+                func_wrapper = self._get_s3_call_wrapper(func)
+                setattr(s3_functions, func_name, func_wrapper)
+            else:
+                logging.warning('S3 function %s not found', func_name)
 
     def _reset_patches(self):
         ServiceAction.__call__ = _service_action_call
+        BaseClient._make_api_call = _client_make_api_call
+        BoundedExecutor.EXECUTOR_CLS = _Executor
+        for func_name, original_func in self.s3_original_funcs.items():
+            setattr(s3_functions, func_name, original_func)
 
     @staticmethod
     def set_request_id_tag(span, response):
@@ -33,38 +68,92 @@ class Boto3Patcher(Patcher):
         # there is no ResponseMetadata for
         # boto3:dynamodb:describe_table
         if metadata:
-            span.set_tag('aws.request_id', metadata['RequestId'])
+            request_id = metadata.get('RequestId')
 
-    def _get_call_wrapper(self):
-        def call_wrapper(service, parent, *args, **kwargs):
+            # when using boto3.client('s3')
+            # instead of boto3.resource('s3'),
+            # there is no RequestId for
+            # boto3:s3:CreateBucket
+            if request_id:
+                span.set_tag('aws.request_id', request_id)
+
+    def _get_service_action_call_wrapper(self):
+        def service_action_call_wrapper(service, parent, *args, **kwargs):
             """Wraps ServiceAction.__call__"""
 
             service_name = parent.meta.service_name
-            operation_name = 'boto3:{}:{}'.format(
-                service_name,
-                xform_name(service._action_model.request.operation)
+            operation_name = xform_name(
+                service._action_model.request.operation
             )
-            span = utils.start_child_span(operation_name=operation_name,
-                                          parent=get_current_span())
 
-            span.set_tag(tags.SPAN_KIND, tags.SPAN_KIND_RPC_CLIENT)
-            span.set_tag(tags.COMPONENT, 'boto3')
-            span.set_tag('boto3.service_name', service_name)
+            return self.perform_call(
+                _service_action_call, 'resource',
+                service_name, operation_name,
+                service, parent, *args, **kwargs
+            )
 
-            with span:
-                try:
-                    response = _service_action_call(service, parent,
-                                                    *args, **kwargs)
-                except ClientError as error:
-                    self.set_request_id_tag(span, error.response)
-                    raise
-                else:
-                    if isinstance(response, dict):
-                        self.set_request_id_tag(span, response)
+        return service_action_call_wrapper
 
-            return response
+    def _get_client_make_api_call_wrapper(self):
+        def make_api_call_wrapper(client, operation_name, api_params):
+            """Wraps BaseClient._make_api_call"""
 
-        return call_wrapper
+            service_name = client._service_model.service_name
+            formatted_operation_name = xform_name(operation_name)
+
+            return self.perform_call(
+                _client_make_api_call, 'client',
+                service_name, formatted_operation_name,
+                client, operation_name, api_params
+            )
+
+        return make_api_call_wrapper
+
+    def _get_s3_call_wrapper(self, original_func):
+        operation_name = original_func.__name__
+
+        def s3_call_wrapper(*args, **kwargs):
+            """Wraps __call__ of S3 client methods"""
+
+            return self.perform_call(
+                original_func, 'client', 's3', operation_name, *args, **kwargs
+            )
+
+        return s3_call_wrapper
+
+    def perform_call(self, original_func, kind, service_name, operation_name,
+                     *args, **kwargs):
+        span = utils.start_child_span(
+            operation_name='boto3:{}:{}:{}'.format(
+                kind, service_name, operation_name
+            ),
+            parent=get_current_span()
+        )
+
+        span.set_tag(tags.SPAN_KIND, tags.SPAN_KIND_RPC_CLIENT)
+        span.set_tag(tags.COMPONENT, 'boto3')
+        span.set_tag('boto3.service_name', service_name)
+
+        with span, span_in_stack_context(span):
+            try:
+                response = original_func(*args, **kwargs)
+            except ClientError as error:
+                self.set_request_id_tag(span, error.response)
+                raise
+            else:
+                if isinstance(response, dict):
+                    self.set_request_id_tag(span, response)
+
+        return response
+
+    def _get_instrumented_executor_cls(self):
+        class InstrumentedExecutor(_Executor):
+            def submit(self, task, *args, **kwargs):
+                return super(InstrumentedExecutor, self).submit(
+                    keep_stack_context(task), *args, **kwargs
+                )
+
+        return InstrumentedExecutor
 
 
 Boto3Patcher.configure_hook_module(globals())

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
             'moto',
             'MySQL-python; python_version=="2.7"',
             'psycopg2-binary',
-            'sqlalchemy>=1.2.0',
+            'sqlalchemy>=1.3.7',
             'pytest',
             'pytest-cov',
             'pytest-localserver',
@@ -64,6 +64,7 @@ setup(
             'redis',
             'Sphinx',
             'sphinx_rtd_theme',
+            'testfixtures',
         ]
     },
 )

--- a/tests/opentracing_instrumentation/test_boto3.py
+++ b/tests/opentracing_instrumentation/test_boto3.py
@@ -1,9 +1,11 @@
 import datetime
+import io
 
 import boto3
 import mock
 import pytest
 import requests
+import testfixtures
 
 from botocore.exceptions import ClientError
 from opentracing.ext import tags
@@ -11,13 +13,16 @@ from opentracing.ext import tags
 from opentracing_instrumentation.client_hooks import boto3 as boto3_hooks
 
 
-DYNAMODB_ENDPOINT_URL = 'http://localhost:8000'
+DYNAMODB_ENDPOINT_URL = 'http://localhost:4569'
+S3_ENDPOINT_URL = 'http://localhost:4572'
+
 DYNAMODB_CONFIG = {
     'endpoint_url': DYNAMODB_ENDPOINT_URL,
     'aws_access_key_id': '-',
     'aws_secret_access_key': '-',
     'region_name': 'us-east-1',
 }
+S3_CONFIG = dict(DYNAMODB_CONFIG, endpoint_url=S3_ENDPOINT_URL)
 
 
 def create_users_table(dynamodb):
@@ -67,7 +72,20 @@ def dynamodb():
     return dynamodb
 
 
-@pytest.fixture(autouse=True, scope='module')
+@pytest.fixture
+def s3_mock():
+    import moto
+    with moto.mock_s3():
+        s3 = boto3.client('s3', region_name='us-east-1')
+        yield s3
+
+
+@pytest.fixture
+def s3():
+    return boto3.client('s3', **S3_CONFIG)
+
+
+@pytest.fixture(autouse=True)
 def patch_boto3():
     boto3_hooks.install_patches()
     try:
@@ -76,17 +94,20 @@ def patch_boto3():
         boto3_hooks.reset_patches()
 
 
-def assert_last_span(operation, tracer, response=None):
+def assert_last_span(kind, service_name, operation, tracer, response=None):
     span = tracer.recorder.get_spans()[-1]
-    request_id = response and response['ResponseMetadata']['RequestId']
-    assert span.operation_name == 'boto3:dynamodb:' + operation
+    request_id = response and response['ResponseMetadata'].get('RequestId')
+    assert span.operation_name == 'boto3:{}:{}:{}'.format(
+        kind, service_name, operation
+    )
     assert span.tags.get(tags.SPAN_KIND) == tags.SPAN_KIND_RPC_CLIENT
     assert span.tags.get(tags.COMPONENT) == 'boto3'
-    assert span.tags.get('boto3.service_name') == 'dynamodb'
-    assert span.tags.get('aws.request_id') == request_id
+    assert span.tags.get('boto3.service_name') == service_name
+    if request_id:
+        assert span.tags.get('aws.request_id') == request_id
 
 
-def _test(dynamodb, tracer):
+def _test_dynamodb(dynamodb, tracer):
     users = dynamodb.Table('users')
 
     response = users.put_item(Item={
@@ -94,32 +115,51 @@ def _test(dynamodb, tracer):
         'first_name': 'Jane',
         'last_name': 'Doe',
     })
-    assert_last_span('put_item', tracer, response)
+    assert_last_span('resource', 'dynamodb', 'put_item', tracer, response)
 
     response = users.get_item(Key={'username': 'janedoe'})
     user = response['Item']
     assert user['first_name'] == 'Jane'
     assert user['last_name'] == 'Doe'
-    assert_last_span('get_item', tracer, response)
+    assert_last_span('resource', 'dynamodb', 'get_item', tracer, response)
 
     try:
         dynamodb.Table('test').delete_item(Key={'username': 'janedoe'})
     except ClientError as error:
         response = error.response
-    assert_last_span('delete_item', tracer, response)
+    assert_last_span('resource', 'dynamodb', 'delete_item', tracer, response)
 
     response = users.creation_date_time
     assert isinstance(response, datetime.datetime)
-    assert_last_span('describe_table', tracer)
+    assert_last_span('resource', 'dynamodb', 'describe_table', tracer)
+
+
+def _test_s3(s3, tracer):
+    fileobj = io.BytesIO(b'test data')
+    bucket = 'test-bucket'
+
+    response = s3.create_bucket(Bucket=bucket)
+    assert_last_span('client', 's3', 'create_bucket', tracer, response)
+
+    response = s3.upload_fileobj(fileobj, bucket, 'test.txt')
+    assert_last_span('client', 's3', 'upload_fileobj', tracer, response)
+
+
+def is_service_running(endpoint_url, expected_status_code):
+    try:
+        # feel free to suggest better solution for this check
+        response = requests.get(endpoint_url, timeout=1)
+        return response.status_code == expected_status_code
+    except requests.exceptions.ConnectionError:
+        return False
 
 
 def is_dynamodb_running():
-    try:
-        # feel free to suggest better solution for this check
-        response = requests.get(DYNAMODB_ENDPOINT_URL, timeout=1)
-        return response.status_code == 400
-    except requests.exceptions.ConnectionError:
-        return False
+    return is_service_running(DYNAMODB_ENDPOINT_URL, 502)
+
+
+def is_s3_running():
+    return is_service_running(S3_ENDPOINT_URL, 200)
 
 
 def is_moto_presented():
@@ -132,14 +172,35 @@ def is_moto_presented():
 
 @pytest.mark.skipif(not is_dynamodb_running(),
                     reason='DynamoDB is not running or cannot connect')
-def test_boto3(dynamodb, tracer):
-    _test(dynamodb, tracer)
+def test_boto3_dynamodb(thread_safe_tracer, dynamodb):
+    _test_dynamodb(dynamodb, thread_safe_tracer)
 
 
 @pytest.mark.skipif(not is_moto_presented(),
                     reason='moto module is not presented')
-def test_boto3_with_moto(dynamodb_mock, tracer):
-    _test(dynamodb_mock, tracer)
+def test_boto3_dynamodb_with_moto(thread_safe_tracer, dynamodb_mock):
+    _test_dynamodb(dynamodb_mock, thread_safe_tracer)
+
+
+@pytest.mark.skipif(not is_s3_running(),
+                    reason='S3 is not running or cannot connect')
+def test_boto3_s3(s3, thread_safe_tracer):
+    _test_s3(s3, thread_safe_tracer)
+
+
+@pytest.mark.skipif(not is_moto_presented(),
+                    reason='moto module is not presented')
+def test_boto3_s3_with_moto(s3_mock, thread_safe_tracer):
+    _test_s3(s3_mock, thread_safe_tracer)
+
+
+@testfixtures.log_capture()
+def test_boto3_s3_missing_func_instrumentation(capture):
+    class Patcher(boto3_hooks.Boto3Patcher):
+        S3_FUNCTIONS_TO_INSTRUMENT = 'missing_func',
+
+    Patcher().install_patches()
+    capture.check(('root', 'WARNING', 'S3 function missing_func not found'))
 
 
 @mock.patch.object(boto3_hooks, 'patcher')

--- a/tests/opentracing_instrumentation/test_sqlalchemy.py
+++ b/tests/opentracing_instrumentation/test_sqlalchemy.py
@@ -42,9 +42,10 @@ def test_db(tracer, session):
     session.commit()
 
     spans = tracer.recorder.get_spans()
-    assert len(spans) == 3
+    assert len(spans) == 4
 
-    sql_pragma_span, sql_create_span, sql_insert_span = spans
-    assert_span(sql_pragma_span, 'PRAGMA')
-    assert_span(sql_create_span, 'CREATE')
-    assert_span(sql_insert_span, 'INSERT')
+    pragma_span_1, pragma_span_2, create_span, insert_span = spans
+    assert_span(pragma_span_1, 'PRAGMA')
+    assert_span(pragma_span_2, 'PRAGMA')
+    assert_span(create_span, 'CREATE')
+    assert_span(insert_span, 'INSERT')

--- a/tests/opentracing_instrumentation/test_thread_safe_request_context.py
+++ b/tests/opentracing_instrumentation/test_thread_safe_request_context.py
@@ -18,43 +18,17 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-from functools import partial
-
 import time
 
-import pytest
-
 from threading import Thread
-from tornado import gen
-from tornado.locks import Condition
 from tornado.stack_context import wrap
-
-from basictracer import BasicTracer
-from basictracer.recorder import InMemoryRecorder
-import opentracing
-from opentracing.scope_managers.tornado import TornadoScopeManager
 
 from opentracing_instrumentation.request_context import (
     get_current_span, span_in_stack_context,
 )
 
-@pytest.fixture
-def tracer():
-    old_tracer = opentracing.tracer
-    t = BasicTracer(
-        recorder=InMemoryRecorder(),
-        scope_manager=TornadoScopeManager(),
-    )
-    t.register_required_propagators()
-    opentracing.tracer = t
 
-    try:
-        yield t
-    finally:
-        opentracing.tracer = old_tracer
-
-
-def test__request_context_is_thread_safe(tracer):
+def test__request_context_is_thread_safe(thread_safe_tracer):
     """
     Port of Uber's internal tornado-extras (by @sema).
 


### PR DESCRIPTION
Hello @yurishkuro,

This PR adds support for `Boto 3` clients including enhanced support for the `S3` client.

These changes also:
 - replace `amazon/dynamodb-local` docker image with `localstack/localstack` docker image for tests
 - fix test for `SQLAlchemy`

Related issue: #101