### PR TITLE
Fix handling of missing psycopg2 module

### DIFF
--- a/opentracing_instrumentation/client_hooks/boto3.py
+++ b/opentracing_instrumentation/client_hooks/boto3.py
@@ -16,7 +16,7 @@ try:
     from botocore.client import BaseClient
     from botocore.exceptions import ClientError
     from s3transfer.futures import BoundedExecutor
-except ImportError:  # pragma: no cover
+except ImportError:
     pass
 else:
     _service_action_call = ServiceAction.__call__

--- a/opentracing_instrumentation/client_hooks/celery.py
+++ b/opentracing_instrumentation/client_hooks/celery.py
@@ -12,7 +12,7 @@ try:
     from celery.signals import (
         before_task_publish, task_prerun, task_success, task_failure
     )
-except ImportError:  # pragma: no cover
+except ImportError:
     pass
 else:
     _task_apply_async = Task.apply_async

--- a/opentracing_instrumentation/client_hooks/mysqldb.py
+++ b/opentracing_instrumentation/client_hooks/mysqldb.py
@@ -26,7 +26,7 @@ from ._patcher import Patcher
 # Try to save the original entry points
 try:
     import MySQLdb
-except ImportError:  # pragma: no cover
+except ImportError:
     pass
 else:
     _MySQLdb_connect = MySQLdb.connect

--- a/opentracing_instrumentation/client_hooks/psycopg2.py
+++ b/opentracing_instrumentation/client_hooks/psycopg2.py
@@ -19,7 +19,6 @@
 # THE SOFTWARE.
 
 from __future__ import absolute_import
-from psycopg2.sql import Composable
 from ._dbapi2 import ContextManagerConnectionWrapper as ConnectionWrapper
 from ._dbapi2 import ConnectionFactory, CursorWrapper, NO_ARG
 from ._singleton import singleton
@@ -27,7 +26,8 @@ from ._singleton import singleton
 # Try to save the original entry points
 try:
     import psycopg2.extensions
-except ImportError:  # pragma: no cover
+    from psycopg2.sql import Composable
+except ImportError:
     pass
 else:
     _psycopg2_connect = psycopg2.connect

--- a/opentracing_instrumentation/client_hooks/requests.py
+++ b/opentracing_instrumentation/client_hooks/requests.py
@@ -38,7 +38,7 @@ log = logging.getLogger(__name__)
 # Try to save the original entry points
 try:
     import requests.adapters
-except ImportError:  # pragma: no cover
+except ImportError:
     pass
 else:
     _HTTPAdapter_send = requests.adapters.HTTPAdapter.send

--- a/opentracing_instrumentation/client_hooks/sqlalchemy.py
+++ b/opentracing_instrumentation/client_hooks/sqlalchemy.py
@@ -34,7 +34,7 @@ log = logging.getLogger(__name__)
 try:
     from sqlalchemy.engine import Engine
     from sqlalchemy import event
-except ImportError:  # pragma: no cover
+except ImportError:
     pass
 
 

--- a/opentracing_instrumentation/client_hooks/strict_redis.py
+++ b/opentracing_instrumentation/client_hooks/strict_redis.py
@@ -29,7 +29,7 @@ from .. import utils
 
 try:
     import redis
-except ImportError:  # pragma: no cover
+except ImportError:
     redis = None
 
 

--- a/opentracing_instrumentation/client_hooks/tornado_http.py
+++ b/opentracing_instrumentation/client_hooks/tornado_http.py
@@ -42,7 +42,7 @@ logger = logging.getLogger(__name__)
 # Try to save the original types for Tornado
 try:
     import tornado.simple_httpclient
-except ImportError:  # pragma: no cover
+except ImportError:
     pass
 else:
     _SimpleAsyncHTTPClient_fetch_impl = \
@@ -51,7 +51,7 @@ else:
 
 try:
     import tornado.curl_httpclient
-except ImportError:  # pragma: no cover
+except ImportError:
     pass
 else:
     _CurlAsyncHTTPClient_fetch_impl = \
@@ -74,7 +74,7 @@ class TracedPatcherBuilder(object):
     def _tornado():
         try:
             import tornado.simple_httpclient as simple
-        except ImportError:  # pragma: no cover
+        except ImportError:
             pass
         else:
             new_fetch_impl = traced_fetch_impl(
@@ -84,7 +84,7 @@ class TracedPatcherBuilder(object):
 
         try:
             import tornado.curl_httpclient as curl
-        except ImportError:  # pragma: no cover
+        except ImportError:
             pass
         else:
             new_fetch_impl = traced_fetch_impl(
@@ -102,7 +102,7 @@ def install_patches():
 def reset_patchers():
     try:
         import tornado.simple_httpclient as simple
-    except ImportError:  # pragma: no cover
+    except ImportError:
         pass
     else:
         setattr(
@@ -112,7 +112,7 @@ def reset_patchers():
         )
     try:
         import tornado.curl_httpclient as curl
-    except ImportError:  # pragma: no cover
+    except ImportError:
         pass
     else:
         setattr(

--- a/opentracing_instrumentation/http_server.py
+++ b/opentracing_instrumentation/http_server.py
@@ -44,7 +44,7 @@ def before_request(request, tracer=None):
         the global opentracing.tracer will be used.
     :return: returns a new, already started span.
     """
-    if tracer is None:  # pragma: no cover
+    if tracer is None:
         tracer = opentracing.tracer
 
     # we need to prepare tags upfront, mainly because RPC_SERVER tag must be

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,3 +13,6 @@ branch = True
 omit =
     setup.py
     tests/*
+
+[tool:pytest]
+addopts = --cov=opentracing_instrumentation --cov-append -rs

--- a/setup.py
+++ b/setup.py
@@ -40,10 +40,6 @@ setup(
     ],
     extras_require={
         'tests': [
-            # coveralls should be required before boto3
-            # to avoid dependency conflict for Python 2.7
-            'coveralls',
-
             'boto3',
             'botocore',
             'celery',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,12 +20,13 @@
 
 import opentracing
 import pytest
-from basictracer import BasicTracer
-from basictracer.recorder import InMemoryRecorder
 from opentracing.scope_managers.tornado import TornadoScopeManager
 
 
 def _get_tracers(scope_manager=None):
+    from basictracer.recorder import InMemoryRecorder
+    from basictracer.tracer import BasicTracer
+
     dummy_tracer = BasicTracer(recorder=InMemoryRecorder(),
                                scope_manager=scope_manager)
     dummy_tracer.register_required_propagators()

--- a/tests/opentracing_instrumentation/test_missing_modules_handling.py
+++ b/tests/opentracing_instrumentation/test_missing_modules_handling.py
@@ -1,0 +1,20 @@
+import os
+from importlib import import_module
+
+import pytest
+
+from opentracing_instrumentation.client_hooks import install_all_patches
+
+
+HOOKS_WITH_PATCHERS = ('boto3', 'celery', 'mysqldb', 'sqlalchemy', 'requests')
+
+
+@pytest.mark.skipif(os.environ.get('TEST_MISSING_MODULES_HANDLING') != '1',
+                    reason='Not this time')
+def test_missing_modules_handling():
+    install_all_patches()
+    for name in HOOKS_WITH_PATCHERS:
+        hook_module = import_module(
+            'opentracing_instrumentation.client_hooks.' + name
+        )
+        assert not hook_module.patcher.applicable

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,20 @@
 [tox]
-envlist = py{27,35,36}-celery{3,4},py37-celery4
+envlist =
+    py{27,35,36}-celery{3,4}
+    py37-celery4
+    py{27,35,36,37}-missing_modules
 skip_missing_interpreters = true
 
 [testenv]
+setenv =
+    missing_modules: TEST_MISSING_MODULES_HANDLING=1
 deps =
     celery3: celery~=3.0
     celery4: celery~=4.0
-    -rrequirements-test.txt
-extras = tests
+    missing_modules: pytest-cov
+extras =
+    !missing_modules: tests
 commands =
-    flake8
-    pytest --cov=opentracing_instrumentation --cov-append -rs
+    !missing_modules: flake8
+    !missing_modules: pytest
+    missing_modules: pytest tests/opentracing_instrumentation/test_missing_modules_handling.py


### PR DESCRIPTION
Hello @yurishkuro,

Execution of `install_all_patches` in the environment with no `psycopg2`/`psycopg2-binary` leads to raising of an `ImportError`.

These changes also:
 - add test for missing modules handling