### PR TITLE
Fix db_span function of _dbapi2

### DIFF
--- a/opentracing_instrumentation/client_hooks/_dbapi2.py
+++ b/opentracing_instrumentation/client_hooks/_dbapi2.py
@@ -53,6 +53,9 @@ def db_span(sql_statement,
     if span is None:
         return empty_ctx_mgr()
 
+    if bytes is not str and isinstance(sql_statement, bytes):
+        sql_statement = sql_statement.decode('utf-8', errors='ignore')
+
     statement = sql_statement.strip()
     add_sql_tag = True
     if sql_statement in _TRANS_TAGS:

--- a/tests/opentracing_instrumentation/test_postgres.py
+++ b/tests/opentracing_instrumentation/test_postgres.py
@@ -124,6 +124,8 @@ def test_install_patches_skip(factory_mock, *mocks):
 @pytest.mark.parametrize('query', [
     # plain string
     '''SELECT %s;''',
+    # bytes
+    b'SELECT %s;',
     # Unicode
     u'''SELECT %s; -- привет''',
     # Composed
@@ -136,7 +138,8 @@ def test_install_patches_skip(factory_mock, *mocks):
     sql.SQL('''SELECT {}''').format(sql.Literal('foobar')),
     # Placeholder
     sql.SQL('''SELECT {}''').format(sql.Placeholder())
-], ids=('str', 'unicode', 'Composed', 'Identifier', 'Literal', 'Placeholder'))
+], ids=('str', 'bytes', 'unicode', 'Composed',
+        'Identifier', 'Literal', 'Placeholder'))
 def test_execute_sql(tracer, engine, connection, method, query):
 
     # Check that executing with objects of ``sql.Composable`` subtypes doesn't


### PR DESCRIPTION
Hi @yurishkuro,

For Python 3, passing `sql_statement` in the form of `bytes` to the `db_span` function of `_dbapi2` module leads to raising of a `TypeError`.

This fix adds safe decoding when it's necessary.