### PR TITLE
Fix test hanging on waiting for DynamoDB

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_script:
 
   # waiting for the DynamoDB mock
   - |
-    while [[ $(curl -so /dev/null -w '%{response_code}' localhost:4569) != '502' ]]
+    while [[ $(curl -so /dev/null -w '%{response_code}' localhost:4569) != '400' ]]
     do
         echo 'waiting 1 sec for DynamoDB...'
         sleep 1


### PR DESCRIPTION
Hi @yurishkuro,

This PR fixes the issue you mentioned in https://github.com/uber-common/opentracing-python-instrumentation/pull/102#issuecomment-645005417.

Best regards!