### PR TITLE
Support non TornadoScopeManager for boto3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - "3306:3306"
 
   localstack:
-    image: localstack/localstack
+    image: localstack/localstack:0.10.5
     environment:
       - SERVICES=dynamodb,s3
     ports:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as fh:
 
 setup(
     name='opentracing_instrumentation',
-    version='3.3.2.dev0',
+    version='3.3.2rc1',
     author='Yuri Shkuro',
     author_email='ys@uber.com',
     description='Tracing Instrumentation using OpenTracing API '

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,7 @@
 import opentracing
 import pytest
 from opentracing.scope_managers.tornado import TornadoScopeManager
+from opentracing.scope_managers.asyncio import AsyncioScopeManager
 
 
 def _get_tracers(scope_manager=None):
@@ -48,6 +49,15 @@ def tracer():
 @pytest.fixture
 def thread_safe_tracer():
     old_tracer, dummy_tracer = _get_tracers(TornadoScopeManager())
+    try:
+        yield dummy_tracer
+    finally:
+        opentracing.tracer = old_tracer
+
+
+@pytest.fixture
+def thread_safe_tracer_non_tornado():
+    old_tracer, dummy_tracer = _get_tracers(AsyncioScopeManager())
     try:
         yield dummy_tracer
     finally:

--- a/tests/opentracing_instrumentation/test_boto3.py
+++ b/tests/opentracing_instrumentation/test_boto3.py
@@ -46,7 +46,7 @@ def create_users_table(dynamodb):
 @pytest.fixture
 def dynamodb_mock():
     import moto
-    with moto.mock_dynamodb2():
+    with moto.mock_dynamodb():
         dynamodb = boto3.resource('dynamodb', region_name='us-east-1')
         create_users_table(dynamodb)
         yield dynamodb

--- a/tests/opentracing_instrumentation/test_boto3.py
+++ b/tests/opentracing_instrumentation/test_boto3.py
@@ -175,24 +175,40 @@ def is_moto_presented():
 def test_boto3_dynamodb(thread_safe_tracer, dynamodb):
     _test_dynamodb(dynamodb, thread_safe_tracer)
 
+@pytest.mark.skipif(not is_dynamodb_running(),
+                    reason='DynamoDB is not running or cannot connect')
+def test_boto3_dynamodb_non_tornado(thread_safe_tracer_non_tornado, dynamodb):
+    _test_dynamodb(dynamodb, thread_safe_tracer_non_tornado)
 
 @pytest.mark.skipif(not is_moto_presented(),
                     reason='moto module is not presented')
 def test_boto3_dynamodb_with_moto(thread_safe_tracer, dynamodb_mock):
     _test_dynamodb(dynamodb_mock, thread_safe_tracer)
 
+@pytest.mark.skipif(not is_moto_presented(),
+                    reason='moto module is not presented')
+def test_boto3_dynamodb_with_moto_non_tornado(thread_safe_tracer_non_tornado, dynamodb_mock):
+    _test_dynamodb(dynamodb_mock, thread_safe_tracer_non_tornado)
 
 @pytest.mark.skipif(not is_s3_running(),
                     reason='S3 is not running or cannot connect')
 def test_boto3_s3(s3, thread_safe_tracer):
     _test_s3(s3, thread_safe_tracer)
 
+@pytest.mark.skipif(not is_s3_running(),
+                    reason='S3 is not running or cannot connect')
+def test_boto3_s3_non_tornado(s3, thread_safe_tracer_non_tornado):
+    _test_s3(s3, thread_safe_tracer_non_tornado)
 
 @pytest.mark.skipif(not is_moto_presented(),
                     reason='moto module is not presented')
 def test_boto3_s3_with_moto(s3_mock, thread_safe_tracer):
     _test_s3(s3_mock, thread_safe_tracer)
 
+@pytest.mark.skipif(not is_moto_presented(),
+                    reason='moto module is not presented')
+def test_boto3_s3_with_moto_non_tornado(s3_mock, thread_safe_tracer_non_tornado):
+    _test_s3(s3_mock, thread_safe_tracer_non_tornado)
 
 @testfixtures.log_capture()
 def test_boto3_s3_missing_func_instrumentation(capture):


### PR DESCRIPTION
Piper users are facing "scope_manager is not TornadoScopeManager" error while migrating to python 3.
Using similar approach to https://github.com/uber-common/opentracing-python-instrumentation/pull/86